### PR TITLE
Strict deployment mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,13 @@
 <img src="https://opensearch.org/assets/brand/SVG/Logo/opensearch_logo_default.svg" height="64px"/>
 
-- [OpenSearch Continous Integration](#opensearch-continous-integration)
+- [OpenSearch Continuous Integration](#opensearch-continuous-integration)
 - [Getting Started](#getting-started)
 - [Deployment](#deployment)
+  - [CI Deployment](#ci-deployment)
   - [Dev Deployment](#dev-deployment)
   - [Executing Optional Tasks](#executing-optional-tasks)
     - [SSL Configuration](#ssl-configuration)
-    - [setup OpenId Connect (OIDC) via Federate](#setup-openid-connect-oidc-via-federate)
+    - [Setup OpenId Connect (OIDC) via Federate](#setup-openid-connect-oidc-via-federate)
   - [Troubleshooting](#troubleshooting)
     - [Main Node](#main-node)
   - [Useful commands](#useful-commands)
@@ -30,6 +31,16 @@ OpenSearch Continuous Integration is an open source CI system for OpenSearch and
 - Deploy stacks with `npm run cdk deploy`
 
 ## Deployment
+
+### CI Deployment
+1. Create another cdk project and depend on this package
+2. Import the config / ci stacks alongside the other resources
+   ```
+   new CIConfigStack(app, 'CI-Config-Beta', {});
+   new CIStack(app, 'CI-Beta', ciSettings);
+   ```
+3. Update the `ciSettings` according to the environment needs such as SSL or strict deployment, see [CIStackProps](./lib/ci-stack.ts) for details.
+4. Deploy using the CI system of your choice.
 
 ### Dev Deployment 
 1. Setup your local machine to credentials to deploy to the AWS Account

--- a/lib/ci-stack.ts
+++ b/lib/ci-stack.ts
@@ -25,8 +25,12 @@ import { CiAuditLogging } from './auditing/ci-audit-logging';
 import { CloudAgentNodeConfig } from './compute/agent-node-config';
 
 export interface CIStackProps extends StackProps {
+  /** Should the Jenkins use https  */
   useSsl?: boolean;
+  /** Should an OIDC provider be installed on Jenkins. */
   runWithOidc?: boolean;
+  /** Additional verification during deployment and resource startup. */
+  strictMode?: boolean;
 }
 
 export class CIStack extends Stack {
@@ -90,6 +94,7 @@ export class CIStack extends Stack {
       oidcCredArn: importedOidcConfigValuesSecretBucketValue.toString(),
       useSsl,
       runWithOidc,
+      failOnCloudInitError: props?.strictMode,
     },
     {
       agentNodeSecurityGroup: securityGroups.agentNodeSG.securityGroupId,

--- a/lib/compute/jenkins-main-node.ts
+++ b/lib/compute/jenkins-main-node.ts
@@ -16,7 +16,7 @@ import { Metric, Unit } from '@aws-cdk/aws-cloudwatch';
 import { join } from 'path';
 import { CloudwatchAgent } from '../constructs/cloudwatch-agent';
 import { JenkinsPlugins } from './jenkins-plugins';
-import { AgentNode, AgentNodeConfig, AgentNodeProps } from './agent-nodes';
+import { AgentNode, AgentNodeProps } from './agent-nodes';
 import { CloudAgentNodeConfig } from './agent-node-config';
 
 interface HttpConfigProps {
@@ -35,6 +35,7 @@ interface OidcFederateProps {
 export interface JenkinsMainNodeProps extends HttpConfigProps, OidcFederateProps{
   readonly vpc: Vpc;
   readonly sg: SecurityGroup;
+  readonly failOnCloudInitError?: boolean;
 }
 
 export class JenkinsMainNode {
@@ -55,7 +56,7 @@ export class JenkinsMainNode {
   }
 
   constructor(stack: Stack,
-    props:JenkinsMainNodeProps,
+    props: JenkinsMainNodeProps,
     agentNodeProps: AgentNodeProps,
     agentNodeConfig: CloudAgentNodeConfig) {
     this.ec2InstanceMetrics = {
@@ -123,7 +124,7 @@ export class JenkinsMainNode {
       }),
       initOptions: {
         timeout: Duration.minutes(20),
-        ignoreFailures: true,
+        ignoreFailures: props.failOnCloudInitError ?? true,
       },
       vpc: props.vpc,
       vpcSubnets: {
@@ -299,7 +300,7 @@ export class JenkinsMainNode {
                   auto_removal: true,
                   log_stream_name: 'jenkins.log',
                   //  2021-07-20 16:15:55.319+0000 [id=868]   INFO    jenkins.InitReactorRunner$1#onAttained: Completed initialization
-                  timestamp_format: '%Y-%m-%d %H:%M:%S.%f%z',
+                  timestamp_format: '%Y-%m-%d %H:%M:%S.%%z',
                 },
               ],
             },

--- a/lib/compute/jenkins-main-node.ts
+++ b/lib/compute/jenkins-main-node.ts
@@ -300,7 +300,7 @@ export class JenkinsMainNode {
                   auto_removal: true,
                   log_stream_name: 'jenkins.log',
                   //  2021-07-20 16:15:55.319+0000 [id=868]   INFO    jenkins.InitReactorRunner$1#onAttained: Completed initialization
-                  timestamp_format: '%Y-%m-%d %H:%M:%S.%%z',
+                  timestamp_format: '%Y-%m-%d %H:%M:%S.%f%z',
                 },
               ],
             },


### PR DESCRIPTION
Adding a strict mode to make sure that cloud-init passes during the
deployment for environments that need more rigor.

Signed-off-by: Peter Nied <petern@amazon.com>

### Check List
- [X] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
