### PR TITLE
Load balancer changes for http to https redirection

### DIFF
--- a/lib/network/ci-external-load-balancer.ts
+++ b/lib/network/ci-external-load-balancer.ts
@@ -42,7 +42,7 @@ export class JenkinsExternalLoadBalancer {
     const accessPort = props.useSsl ? 443 : 80;
 
     this.listener = this.loadBalancer.addListener('JenkinsListener', {
-      sslPolicy: SslPolicy.RECOMMENDED,
+      sslPolicy: SslPolicy.TLS12,
       port: accessPort,
       open: true,
       certificates: props.useSsl ? [props.listenerCertificate] : undefined,

--- a/lib/network/ci-external-load-balancer.ts
+++ b/lib/network/ci-external-load-balancer.ts
@@ -10,7 +10,8 @@ import {
   Instance, Peer, SecurityGroup, Vpc,
 } from '@aws-cdk/aws-ec2';
 import {
-  ApplicationListener, ApplicationLoadBalancer, ApplicationTargetGroup, ListenerCertificate, Protocol,
+  ApplicationListener, ApplicationLoadBalancer, ApplicationProtocol, ApplicationProtocolVersion, ApplicationTargetGroup,
+  ListenerCertificate, Protocol, SslPolicy,
 } from '@aws-cdk/aws-elasticloadbalancingv2';
 import { InstanceTarget } from '@aws-cdk/aws-elasticloadbalancingv2-targets';
 import { CfnOutput, Stack } from '@aws-cdk/core';
@@ -41,10 +42,20 @@ export class JenkinsExternalLoadBalancer {
     const accessPort = props.useSsl ? 443 : 80;
 
     this.listener = this.loadBalancer.addListener('JenkinsListener', {
+      sslPolicy: SslPolicy.RECOMMENDED,
       port: accessPort,
       open: true,
       certificates: props.useSsl ? [props.listenerCertificate] : undefined,
     });
+
+    if (props.useSsl) {
+      this.loadBalancer.addRedirect({
+        sourceProtocol: ApplicationProtocol.HTTP,
+        sourcePort: 80,
+        targetProtocol: ApplicationProtocol.HTTPS,
+        targetPort: 443,
+      });
+    }
 
     this.targetGroup = this.listener.addTargets('MainJenkinsNodeTarget', {
       port: accessPort,

--- a/lib/security/ci-security-groups.ts
+++ b/lib/security/ci-security-groups.ts
@@ -27,8 +27,11 @@ export class JenkinsSecurityGroups {
       description: 'Main node of Jenkins',
     });
 
-    const accessPort = useSsl ? 443 : 80;
+    const accessPort = 80;
     this.mainNodeSG.addIngressRule(this.externalAccessSG, Port.tcp(accessPort));
+    if (useSsl) {
+      this.mainNodeSG.addIngressRule(this.externalAccessSG, Port.tcp(443));
+    }
 
     this.agentNodeSG = new SecurityGroup(stack, 'AgentNodeSG', {
       vpc,


### PR DESCRIPTION
Signed-off-by: Sayali Gaikawad <gaiksaya@amazon.com>

### Description
After #69 the issue for redirection still existed. This change fixes that.
Deployed the stack with self signed certs and tried http://url. It auto-redirected to https
 
### Issues Resolved
Resolves #68 
 
### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
