### PR TITLE
set ssl policy to be undefined when useSsl is false

### DIFF
--- a/lib/network/ci-external-load-balancer.ts
+++ b/lib/network/ci-external-load-balancer.ts
@@ -42,7 +42,7 @@ export class JenkinsExternalLoadBalancer {
     const accessPort = props.useSsl ? 443 : 80;
 
     this.listener = this.loadBalancer.addListener('JenkinsListener', {
-      sslPolicy: SslPolicy.TLS12,
+      sslPolicy: props.useSsl ? SslPolicy.TLS12 : undefined,
       port: accessPort,
       open: true,
       certificates: props.useSsl ? [props.listenerCertificate] : undefined,


### PR DESCRIPTION
Signed-off-by: Abhinav Gupta <abhng@amazon.com>

### Description
set ssl policy to be null when useSsl is false
 
### Issues Resolved
deploy with ssl false failed
 
### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
