### PR TITLE
Enable Role Based Authentication when OIDC is enabled

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ $aws secretsmanager put-secret-value \
    1. `cdk deploy CI-Dev -c runWithOidc=false -c useSsl=true`
 1. Continue with [next steps](#dev-deployment) 
 
-_Note: With OIDC enabled, Role Based Authentication is also enabled that helps users/admins from locking out. You can modify who gets the admin access based on your choice of OIDC by modifying the array [here](https://github.com/opensearch-project/opensearch-ci/blob/main/lib/compute//jenkins-main-node-config.ts)_
+_Note: With OIDC enabled, Role Based Authentication is also enabled that helps users/admins from locking out. You can modify who gets the admin access based on your choice of OIDC by modifying the array [here](https://github.com/opensearch-project/opensearch-ci/blob/main/lib/compute/jenkins-main-node-config.ts)_
 
 ### Troubleshooting
 #### Main Node

--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ $aws secretsmanager put-secret-value \
    1. `cdk deploy CI-Dev -c runWithOidc=false -c useSsl=true`
 1. Continue with [next steps](#dev-deployment) 
 
-Note: With OIDC enabled, Role Based Authentication is also enabled that helps users/admins from locking out. You can modify who gets the admin access based on your choice of OIDC by modifying the array [here](https://github.com/opensearch-project/opensearch-ci/blob/main/lib/compute/jenkins-main-node.ts#L479-L487)
+_Note: With OIDC enabled, Role Based Authentication is also enabled that helps users/admins from locking out. You can modify who gets the admin access based on your choice of OIDC by modifying the array [here](https://github.com/opensearch-project/opensearch-ci/blob/main/lib/compute/jenkins-main-node.ts#L479-L487)_
 
 ### Troubleshooting
 #### Main Node

--- a/README.md
+++ b/README.md
@@ -101,12 +101,11 @@ $aws secretsmanager put-secret-value \
     --secret-id MyTestDatabaseSecret_or_ARN \
     --secret-string file://mycreds.json_or_value
     ```
+1. Add additional `adminUsers` for role based authentication according to your needs, see [CIStackProps](./lib/ci-stack.ts) for details.
 1. Run with parameter with one of the following (refer [this](#ssl-configuration) for value of `useSsL`) -
    1. `npm run cdk deploy CI-Dev -- -c runWithOidc=false -c useSsl=true` or,
    1. `cdk deploy CI-Dev -c runWithOidc=false -c useSsl=true`
-1. Continue with [next steps](#dev-deployment) 
-
-_Note: With OIDC enabled, Role Based Authentication is also enabled that helps users/admins from locking out. You can modify who gets the admin access based on your choice of OIDC by modifying the array [here](https://github.com/opensearch-project/opensearch-ci/blob/main/lib/compute/jenkins-main-node-config.ts)_
+1. Continue with [next steps](#dev-deployment)
 
 ### Troubleshooting
 #### Main Node

--- a/README.md
+++ b/README.md
@@ -106,6 +106,8 @@ $aws secretsmanager put-secret-value \
    1. `cdk deploy CI-Dev -c runWithOidc=false -c useSsl=true`
 1. Continue with [next steps](#dev-deployment) 
 
+Note: With OIDC enabled, Role Based Authentication is also enabled that helps users/admins from locking out. You can modify who gets the admin access based on your choice of OIDC by modifying the array [here](https://github.com/opensearch-project/opensearch-ci/blob/main/lib/compute/jenkins-main-node.ts#L479-L487)
+
 ### Troubleshooting
 #### Main Node
 Useful links

--- a/README.md
+++ b/README.md
@@ -103,8 +103,8 @@ $aws secretsmanager put-secret-value \
     ```
 1. Add additional `adminUsers` for role based authentication according to your needs, see [CIStackProps](./lib/ci-stack.ts) for details.
 1. Run with parameter with one of the following (refer [this](#ssl-configuration) for value of `useSsL`) -
-   1. `npm run cdk deploy CI-Dev -- -c runWithOidc=false -c useSsl=true` or,
-   1. `cdk deploy CI-Dev -c runWithOidc=false -c useSsl=true`
+   1. `npm run cdk deploy CI-Dev -- -c runWithOidc=true -c useSsl=true` or,
+   1. `cdk deploy CI-Dev -c runWithOidc=true -c useSsl=true`
 1. Continue with [next steps](#dev-deployment)
 
 ### Troubleshooting

--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ $aws secretsmanager put-secret-value \
    1. `cdk deploy CI-Dev -c runWithOidc=false -c useSsl=true`
 1. Continue with [next steps](#dev-deployment) 
 
-_Note: With OIDC enabled, Role Based Authentication is also enabled that helps users/admins from locking out. You can modify who gets the admin access based on your choice of OIDC by modifying the array [here](https://github.com/opensearch-project/opensearch-ci/blob/main/lib/compute/jenkins-main-node.ts#L479-L487)_
+_Note: With OIDC enabled, Role Based Authentication is also enabled that helps users/admins from locking out. You can modify who gets the admin access based on your choice of OIDC by modifying the array [here](https://github.com/opensearch-project/opensearch-ci/blob/main/lib/compute//jenkins-main-node-config.ts)_
 
 ### Troubleshooting
 #### Main Node

--- a/lib/ci-stack.ts
+++ b/lib/ci-stack.ts
@@ -31,6 +31,8 @@ export interface CIStackProps extends StackProps {
   runWithOidc?: boolean;
   /** Additional verification during deployment and resource startup. */
   strictMode?: boolean;
+  /** Users with admin access during initial deployment */
+  adminUsers?: Array<String>;
 }
 
 export class CIStack extends Stack {
@@ -95,6 +97,7 @@ export class CIStack extends Stack {
       useSsl,
       runWithOidc,
       failOnCloudInitError: props?.strictMode,
+      adminUsers: props?.adminUsers,
     },
     {
       agentNodeSecurityGroup: securityGroups.agentNodeSG.securityGroupId,

--- a/lib/compute/jenkins-main-node-config.ts
+++ b/lib/compute/jenkins-main-node-config.ts
@@ -1,0 +1,88 @@
+/**
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+export class JenkinsMainNodeConfig {
+  public static oidcConfigFields() : string[][] {
+    return [['clientId', 'replace'],
+      ['clientSecret', 'replace'],
+      ['wellKnownOpenIDConfigurationUrl', 'replace'],
+      ['tokenServerUrl', 'replace'],
+      ['authorizationServerUrl', 'replace'],
+      ['userInfoServerUrl', 'replace'],
+      ['userNameField', 'sub'],
+      ['scopes', 'openid'],
+      ['disableSslVerification', 'false'],
+      ['logoutFromOpenidProvider', 'true'],
+      ['postLogoutRedirectUrl', ''],
+      ['escapeHatchEnabled', 'false'],
+      ['escapeHatchSecret', 'random']];
+  }
+
+  public static rolePermissions() : string[] {
+    return ['hudson.model.Hudson.Manage',
+      'hudson.model.Computer.Connect',
+      'hudson.model.Hudson.UploadPlugins',
+      'com.synopsys.arc.jenkins.plugins.ownership.OwnershipPlugin.Jobs',
+      'hudson.model.Hudson.ConfigureUpdateCenter',
+      'hudson.model.Hudson.Administer',
+      'hudson.model.Item.Cancel',
+      'com.cloudbees.plugins.credentials.CredentialsProvider.View',
+      'hudson.model.Computer.Delete',
+      'hudson.model.Item.Build',
+      'hudson.plugins.jobConfigHistory.JobConfigHistory.DeleteEntry',
+      'hudson.model.Item.Move',
+      'com.cloudbees.plugins.credentials.CredentialsProvider.Update',
+      'org.jenkins.plugins.lockableresources.LockableResourcesManager.Steal',
+      'hudson.model.Item.Create',
+      'com.cloudbees.plugins.credentials.CredentialsProvider.Delete',
+      'hudson.model.Run.Replay',
+      'hudson.model.Item.WipeOut',
+      'hudson.model.Hudson.RunScripts',
+      'hudson.model.Hudson.SystemRead',
+      'hudson.model.View.Create',
+      'hudson.model.Computer.ExtendedRead',
+      'hudson.model.Computer.Configure',
+      'com.synopsys.arc.jenkins.plugins.ownership.OwnershipPlugin.Nodes',
+      'com.cloudbees.plugins.credentials.CredentialsProvider.UseOwn',
+      'hudson.model.Run.Update',
+      'hudson.model.View.Delete',
+      'hudson.model.Run.Delete',
+      'com.cloudbees.plugins.credentials.CredentialsProvider.ManageDomains',
+      'hudson.model.Computer.Create',
+      'hudson.model.View.Configure',
+      'hudson.model.Computer.Build',
+      'hudson.model.Item.Configure',
+      'hudson.model.Item.Read',
+      'org.jenkins.plugins.lockableresources.LockableResourcesManager.Unlock',
+      'hudson.model.Item.ExtendedRead',
+      'hudson.scm.SCM.Tag',
+      'hudson.model.Item.Discover',
+      'hudson.model.Hudson.Read',
+      'hudson.model.Item.Workspace',
+      'hudson.model.Computer.Provision',
+      'hudson.model.View.Read',
+      'org.jenkins.plugins.lockableresources.LockableResourcesManager.View',
+      'hudson.model.Item.Delete',
+      'com.cloudbees.plugins.credentials.CredentialsProvider.Create',
+      'hudson.model.Computer.Disconnect',
+      'hudson.model.Run.Artifacts',
+      'com.cloudbees.plugins.credentials.CredentialsProvider.UseItem',
+      'org.jenkins.plugins.lockableresources.LockableResourcesManager.Reserve'];
+  }
+
+  public static admins() : string[] {
+    return [
+      'admin',
+      'gaiksaya',
+      'zhujiaxi',
+      'abhng',
+      'bbarani',
+      'zelinhao',
+    ];
+  }
+}

--- a/lib/compute/jenkins-main-node-config.ts
+++ b/lib/compute/jenkins-main-node-config.ts
@@ -6,6 +6,8 @@
  * compatible open source license.
  */
 
+import { JenkinsMainNode } from './jenkins-main-node';
+
 export class JenkinsMainNodeConfig {
   public static oidcConfigFields() : string[][] {
     return [['clientId', 'replace'],
@@ -73,16 +75,5 @@ export class JenkinsMainNodeConfig {
       'hudson.model.Run.Artifacts',
       'com.cloudbees.plugins.credentials.CredentialsProvider.UseItem',
       'org.jenkins.plugins.lockableresources.LockableResourcesManager.Reserve'];
-  }
-
-  public static admins() : string[] {
-    return [
-      'admin',
-      'gaiksaya',
-      'zhujiaxi',
-      'abhng',
-      'bbarani',
-      'zelinhao',
-    ];
   }
 }

--- a/lib/compute/jenkins-main-node.ts
+++ b/lib/compute/jenkins-main-node.ts
@@ -349,7 +349,8 @@ export class JenkinsMainNode {
       InitFile.fromFileInline('/var/lib/jenkins/jenkins.yaml', join(__dirname, '../../resources/jenkins.yaml')),
 
       // Enabling Role Based Authentication by editing config.xml file:
-      InitCommand.shellCommand('xmlstarlet ed -L -d /hudson/authorizationStrategy'
+      InitCommand.shellCommand(oidcFederateProps.runWithOidc
+        ?'xmlstarlet ed -L -d /hudson/authorizationStrategy'
         + ' -s /hudson -t elem -n authorizationStrategy -v " "'
         + ' -i //authorizationStrategy -t attr -n "class" -v "com.michelin.cio.hudson.plugins.rolestrategy.RoleBasedAuthorizationStrategy"'
         + ' -s /hudson/authorizationStrategy -t elem -n roleMap'
@@ -367,7 +368,8 @@ export class JenkinsMainNode {
         + `${this.admins(oidcFederateProps.adminUsers).map(((e) => ` -s /hudson/authorizationStrategy/roleMap[2]/role/assignedSIDs -t elem -n "sid" -v ${e}`)).join(' ')}`
         + ' -s /hudson/authorizationStrategy --type elem -n roleMap'
         + ' -i /hudson/authorizationStrategy/roleMap[3] -t attr -n "type" -v "slaveRolesRoles"'
-        + ' /var/lib/jenkins/config.xml'),
+        + ' /var/lib/jenkins/config.xml'
+        : 'echo Not enabling Role based authenication'),
 
       // If devMode is false, first line extracts the oidcFederateProps as json from the secret manager
       // xmlstarlet is used to setup the securityRealm values for oidc by editing the jenkins' config.xml file

--- a/lib/compute/jenkins-main-node.ts
+++ b/lib/compute/jenkins-main-node.ts
@@ -359,7 +359,6 @@ export class JenkinsMainNode {
         + ' -i /hudson/authorizationStrategy/roleMap[2]/role -t attr -n "name" -v "admin"'
         + ' -i /hudson/authorizationStrategy/roleMap[2]/role -t attr -n "pattern" -v ".*"'
         + ' -s /hudson/authorizationStrategy/roleMap[2]/role -t elem -n permissions -v " "'
-        // eslint-disable-next-line max-len
         + `${this.rolePermissions().map((e) => ` -s /hudson/authorizationStrategy/roleMap[2]/role/permissions -t elem -n "permission" -v ${e}`).join(' ')}`
         + ' -s /hudson/authorizationStrategy/roleMap[2]/role -t elem -n "assignedSIDs" -v " " '
         + `${this.admins().map(((e) => ` -s /hudson/authorizationStrategy/roleMap[2]/role/assignedSIDs -t elem -n "sid" -v ${e}`)).join(' ')}`

--- a/lib/compute/jenkins-main-node.ts
+++ b/lib/compute/jenkins-main-node.ts
@@ -346,6 +346,32 @@ export class JenkinsMainNode {
 
       InitFile.fromFileInline('/var/lib/jenkins/jenkins.yaml', join(__dirname, '../../resources/jenkins.yaml')),
 
+      // Enabling Role Based Authentication by editing config.xml file:
+      InitCommand.shellCommand(oidcFederateProps.runWithOidc
+        ? 'xmlstarlet ed -L -d /hudson/authorizationStrategy'
+        + ' -s /hudson -t elem -n authorizationStrategy -v " "'
+        + ' -i //authorizationStrategy -t attr -n "class" -v "com.michelin.cio.hudson.plugins.rolestrategy.RoleBasedAuthorizationStrategy"'
+        + ' -s /hudson/authorizationStrategy -t elem -n roleMap'
+        + ' -i /hudson/authorizationStrategy/roleMap -t attr -n "type" -v "projectRoles"'
+        + ' -s /hudson/authorizationStrategy --type elem -n roleMap'
+        + ' -i /hudson/authorizationStrategy/roleMap[2] -t attr -n "type" -v "globalRoles"'
+        + ' -s /hudson/authorizationStrategy/roleMap[2] -t elem -n role -v " "'
+        + ' -i /hudson/authorizationStrategy/roleMap[2]/role -t attr -n "name" -v "admin"'
+        + ' -i /hudson/authorizationStrategy/roleMap[2]/role -t attr -n "pattern" -v ".*"'
+        + ' -s /hudson/authorizationStrategy/roleMap[2]/role -t elem -n permissions -v " "'
+        // eslint-disable-next-line max-len
+        + `${this.rolePermissions().map((e) => ` -s /hudson/authorizationStrategy/roleMap[2]/role/permissions -t elem -n "permission" -v ${e}`).join(' ')}`
+        + ' -s /hudson/authorizationStrategy/roleMap[2]/role -t elem -n "assignedSIDs" -v " " '
+        + `${this.admins().map(((e) => ` -s /hudson/authorizationStrategy/roleMap[2]/role/assignedSIDs -t elem -n "sid" -v ${e}`)).join(' ')}`
+        + ' -s /hudson/authorizationStrategy --type elem -n roleMap'
+        + ' -i /hudson/authorizationStrategy/roleMap[3] -t attr -n "type" -v "slaveRolesRoles"'
+        + ' /var/lib/jenkins/config.xml'
+        : 'echo Not enabling Role based authenication '),
+
+      InitCommand.shellCommand(oidcFederateProps.runWithOidc
+        ? `java -jar /jenkins-cli.jar -s http://localhost:8080 -auth @${JenkinsMainNode.JENKINS_DEFAULT_ID_PASS_PATH} reload-configuration`
+        : 'echo OIDC is disabled hence not reloading the config'),
+
       // If devMode is false, first line extracts the oidcFederateProps as json from the secret manager
       // xmlstarlet is used to setup the securityRealm values for oidc by editing the jenkins' config.xml file
       InitCommand.shellCommand(oidcFederateProps.runWithOidc
@@ -397,5 +423,68 @@ export class JenkinsMainNode {
       ['postLogoutRedirectUrl', ''],
       ['escapeHatchEnabled', 'false'],
       ['escapeHatchSecret', 'random']];
+  }
+
+  public static rolePermissions() : string[] {
+    return ['hudson.model.Hudson.Manage',
+      'hudson.model.Computer.Connect',
+      'hudson.model.Hudson.UploadPlugins',
+      'com.synopsys.arc.jenkins.plugins.ownership.OwnershipPlugin.Jobs',
+      'hudson.model.Hudson.ConfigureUpdateCenter',
+      'hudson.model.Hudson.Administer',
+      'hudson.model.Item.Cancel',
+      'com.cloudbees.plugins.credentials.CredentialsProvider.View',
+      'hudson.model.Computer.Delete',
+      'hudson.model.Item.Build',
+      'hudson.plugins.jobConfigHistory.JobConfigHistory.DeleteEntry',
+      'hudson.model.Item.Move',
+      'com.cloudbees.plugins.credentials.CredentialsProvider.Update',
+      'org.jenkins.plugins.lockableresources.LockableResourcesManager.Steal',
+      'hudson.model.Item.Create',
+      'com.cloudbees.plugins.credentials.CredentialsProvider.Delete',
+      'hudson.model.Run.Replay',
+      'hudson.model.Item.WipeOut',
+      'hudson.model.Hudson.RunScripts',
+      'hudson.model.Hudson.SystemRead',
+      'hudson.model.View.Create',
+      'hudson.model.Computer.ExtendedRead',
+      'hudson.model.Computer.Configure',
+      'com.synopsys.arc.jenkins.plugins.ownership.OwnershipPlugin.Nodes',
+      'com.cloudbees.plugins.credentials.CredentialsProvider.UseOwn',
+      'hudson.model.Run.Update',
+      'hudson.model.View.Delete',
+      'hudson.model.Run.Delete',
+      'com.cloudbees.plugins.credentials.CredentialsProvider.ManageDomains',
+      'hudson.model.Computer.Create',
+      'hudson.model.View.Configure',
+      'hudson.model.Computer.Build',
+      'hudson.model.Item.Configure',
+      'hudson.model.Item.Read',
+      'org.jenkins.plugins.lockableresources.LockableResourcesManager.Unlock',
+      'hudson.model.Item.ExtendedRead',
+      'hudson.scm.SCM.Tag',
+      'hudson.model.Item.Discover',
+      'hudson.model.Hudson.Read',
+      'hudson.model.Item.Workspace',
+      'hudson.model.Computer.Provision',
+      'hudson.model.View.Read',
+      'org.jenkins.plugins.lockableresources.LockableResourcesManager.View',
+      'hudson.model.Item.Delete',
+      'com.cloudbees.plugins.credentials.CredentialsProvider.Create',
+      'hudson.model.Computer.Disconnect',
+      'hudson.model.Run.Artifacts',
+      'com.cloudbees.plugins.credentials.CredentialsProvider.UseItem',
+      'org.jenkins.plugins.lockableresources.LockableResourcesManager.Reserve'];
+  }
+
+  public static admins() : string[] {
+    return [
+      'admin',
+      'gaiksaya',
+      'zhujiaxi',
+      'abhng',
+      'bbarani',
+      'zelinhao',
+    ];
   }
 }

--- a/test/compute/jenkins-main-node-config.test.ts
+++ b/test/compute/jenkins-main-node-config.test.ts
@@ -1,0 +1,100 @@
+/**
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+import { JenkinsMainNodeConfig } from '../../lib/compute/jenkins-main-node-config';
+
+test('Verify config.xml fields for jenkins OIDC', async () => {
+  expect(JenkinsMainNodeConfig.oidcConfigFields()).toBeInstanceOf(Array);
+
+  const oidcConfigFields : string[][] = [['clientId', 'replace'],
+    ['clientSecret', 'replace'],
+    ['wellKnownOpenIDConfigurationUrl', 'replace'],
+    ['tokenServerUrl', 'replace'],
+    ['authorizationServerUrl', 'replace'],
+    ['userInfoServerUrl', 'replace'],
+    ['userNameField', 'sub'],
+    ['scopes', 'openid'],
+    ['disableSslVerification', 'false'],
+    ['logoutFromOpenidProvider', 'true'],
+    ['postLogoutRedirectUrl', ''],
+    ['escapeHatchEnabled', 'false'],
+    ['escapeHatchSecret', 'random']];
+
+  expect(JSON.stringify(JenkinsMainNodeConfig.oidcConfigFields()) === JSON.stringify(oidcConfigFields)).toBeTruthy();
+});
+
+test('Verify config.xml fields for jenkins Role Based Auth', async () => {
+  expect(JenkinsMainNodeConfig.rolePermissions()).toBeInstanceOf(Array);
+
+  const rolePermissions : string[] = ['hudson.model.Hudson.Manage',
+    'hudson.model.Computer.Connect',
+    'hudson.model.Hudson.UploadPlugins',
+    'com.synopsys.arc.jenkins.plugins.ownership.OwnershipPlugin.Jobs',
+    'hudson.model.Hudson.ConfigureUpdateCenter',
+    'hudson.model.Hudson.Administer',
+    'hudson.model.Item.Cancel',
+    'com.cloudbees.plugins.credentials.CredentialsProvider.View',
+    'hudson.model.Computer.Delete',
+    'hudson.model.Item.Build',
+    'hudson.plugins.jobConfigHistory.JobConfigHistory.DeleteEntry',
+    'hudson.model.Item.Move',
+    'com.cloudbees.plugins.credentials.CredentialsProvider.Update',
+    'org.jenkins.plugins.lockableresources.LockableResourcesManager.Steal',
+    'hudson.model.Item.Create',
+    'com.cloudbees.plugins.credentials.CredentialsProvider.Delete',
+    'hudson.model.Run.Replay',
+    'hudson.model.Item.WipeOut',
+    'hudson.model.Hudson.RunScripts',
+    'hudson.model.Hudson.SystemRead',
+    'hudson.model.View.Create',
+    'hudson.model.Computer.ExtendedRead',
+    'hudson.model.Computer.Configure',
+    'com.synopsys.arc.jenkins.plugins.ownership.OwnershipPlugin.Nodes',
+    'com.cloudbees.plugins.credentials.CredentialsProvider.UseOwn',
+    'hudson.model.Run.Update',
+    'hudson.model.View.Delete',
+    'hudson.model.Run.Delete',
+    'com.cloudbees.plugins.credentials.CredentialsProvider.ManageDomains',
+    'hudson.model.Computer.Create',
+    'hudson.model.View.Configure',
+    'hudson.model.Computer.Build',
+    'hudson.model.Item.Configure',
+    'hudson.model.Item.Read',
+    'org.jenkins.plugins.lockableresources.LockableResourcesManager.Unlock',
+    'hudson.model.Item.ExtendedRead',
+    'hudson.scm.SCM.Tag',
+    'hudson.model.Item.Discover',
+    'hudson.model.Hudson.Read',
+    'hudson.model.Item.Workspace',
+    'hudson.model.Computer.Provision',
+    'hudson.model.View.Read',
+    'org.jenkins.plugins.lockableresources.LockableResourcesManager.View',
+    'hudson.model.Item.Delete',
+    'com.cloudbees.plugins.credentials.CredentialsProvider.Create',
+    'hudson.model.Computer.Disconnect',
+    'hudson.model.Run.Artifacts',
+    'com.cloudbees.plugins.credentials.CredentialsProvider.UseItem',
+    'org.jenkins.plugins.lockableresources.LockableResourcesManager.Reserve'];
+
+  expect(JSON.stringify(JenkinsMainNodeConfig.rolePermissions()) === JSON.stringify(rolePermissions)).toBeTruthy();
+});
+
+test('Verify initial admin users for when OIDC is enabled', async () => {
+  expect(JenkinsMainNodeConfig.admins()).toBeInstanceOf(Array);
+
+  const admins : string[] = [
+    'admin',
+    'gaiksaya',
+    'zhujiaxi',
+    'abhng',
+    'bbarani',
+    'zelinhao',
+  ];
+
+  expect(JSON.stringify(JenkinsMainNodeConfig.admins()) === JSON.stringify(admins)).toBeTruthy();
+});

--- a/test/compute/jenkins-main-node-config.test.ts
+++ b/test/compute/jenkins-main-node-config.test.ts
@@ -6,6 +6,7 @@
  * compatible open source license.
  */
 
+import { JenkinsMainNode } from '../../lib/compute/jenkins-main-node';
 import { JenkinsMainNodeConfig } from '../../lib/compute/jenkins-main-node-config';
 
 test('Verify config.xml fields for jenkins OIDC', async () => {
@@ -85,16 +86,24 @@ test('Verify config.xml fields for jenkins Role Based Auth', async () => {
 });
 
 test('Verify initial admin users for when OIDC is enabled', async () => {
-  expect(JenkinsMainNodeConfig.admins()).toBeInstanceOf(Array);
+  expect(JenkinsMainNode.admins()).toBeInstanceOf(Array);
 
   const admins : string[] = [
     'admin',
-    'gaiksaya',
-    'zhujiaxi',
-    'abhng',
-    'bbarani',
-    'zelinhao',
   ];
 
-  expect(JSON.stringify(JenkinsMainNodeConfig.admins()) === JSON.stringify(admins)).toBeTruthy();
+  expect(JSON.stringify(JenkinsMainNode.admins()) === JSON.stringify(admins)).toBeTruthy();
+});
+
+test('Verify additional admin users are added', async () => {
+  expect(JenkinsMainNode.admins()).toBeInstanceOf(Array);
+
+  const additionalAdminUsers: String[] = ['admin1', 'admin2'];
+  const admins : string[] = [
+    'admin',
+    'admin1',
+    'admin2',
+  ];
+
+  expect(JSON.stringify(JenkinsMainNode.admins(additionalAdminUsers)) === JSON.stringify(admins)).toBeTruthy();
 });

--- a/test/compute/jenkins-main-node.test.ts
+++ b/test/compute/jenkins-main-node.test.ts
@@ -23,7 +23,7 @@ describe('JenkinsMainNode Config Elements', () => {
 
   // THEN
   test('Config elements expected counts', async () => {
-    expect(configElements.filter((e) => e.elementType === 'COMMAND')).toHaveLength(38);
+    expect(configElements.filter((e) => e.elementType === 'COMMAND')).toHaveLength(37);
     expect(configElements.filter((e) => e.elementType === 'PACKAGE')).toHaveLength(14);
     expect(configElements.filter((e) => e.elementType === 'FILE')).toHaveLength(3);
   });

--- a/test/compute/jenkins-main-node.test.ts
+++ b/test/compute/jenkins-main-node.test.ts
@@ -23,7 +23,7 @@ describe('JenkinsMainNode Config Elements', () => {
 
   // THEN
   test('Config elements expected counts', async () => {
-    expect(configElements.filter((e) => e.elementType === 'COMMAND')).toHaveLength(35);
+    expect(configElements.filter((e) => e.elementType === 'COMMAND')).toHaveLength(38);
     expect(configElements.filter((e) => e.elementType === 'PACKAGE')).toHaveLength(14);
     expect(configElements.filter((e) => e.elementType === 'FILE')).toHaveLength(3);
   });
@@ -51,6 +51,77 @@ test('Verify config.xml fields for jenkins OIDC', async () => {
     ['escapeHatchSecret', 'random']];
 
   expect(JSON.stringify(JenkinsMainNode.oidcConfigFields()) === JSON.stringify(oidcConfigFields)).toBeTruthy();
+});
+
+test('Verify config.xml fields for jenkins Role Based Auth', async () => {
+  expect(JenkinsMainNode.rolePermissions()).toBeInstanceOf(Array);
+
+  const rolePermissions : string[] = ['hudson.model.Hudson.Manage',
+    'hudson.model.Computer.Connect',
+    'hudson.model.Hudson.UploadPlugins',
+    'com.synopsys.arc.jenkins.plugins.ownership.OwnershipPlugin.Jobs',
+    'hudson.model.Hudson.ConfigureUpdateCenter',
+    'hudson.model.Hudson.Administer',
+    'hudson.model.Item.Cancel',
+    'com.cloudbees.plugins.credentials.CredentialsProvider.View',
+    'hudson.model.Computer.Delete',
+    'hudson.model.Item.Build',
+    'hudson.plugins.jobConfigHistory.JobConfigHistory.DeleteEntry',
+    'hudson.model.Item.Move',
+    'com.cloudbees.plugins.credentials.CredentialsProvider.Update',
+    'org.jenkins.plugins.lockableresources.LockableResourcesManager.Steal',
+    'hudson.model.Item.Create',
+    'com.cloudbees.plugins.credentials.CredentialsProvider.Delete',
+    'hudson.model.Run.Replay',
+    'hudson.model.Item.WipeOut',
+    'hudson.model.Hudson.RunScripts',
+    'hudson.model.Hudson.SystemRead',
+    'hudson.model.View.Create',
+    'hudson.model.Computer.ExtendedRead',
+    'hudson.model.Computer.Configure',
+    'com.synopsys.arc.jenkins.plugins.ownership.OwnershipPlugin.Nodes',
+    'com.cloudbees.plugins.credentials.CredentialsProvider.UseOwn',
+    'hudson.model.Run.Update',
+    'hudson.model.View.Delete',
+    'hudson.model.Run.Delete',
+    'com.cloudbees.plugins.credentials.CredentialsProvider.ManageDomains',
+    'hudson.model.Computer.Create',
+    'hudson.model.View.Configure',
+    'hudson.model.Computer.Build',
+    'hudson.model.Item.Configure',
+    'hudson.model.Item.Read',
+    'org.jenkins.plugins.lockableresources.LockableResourcesManager.Unlock',
+    'hudson.model.Item.ExtendedRead',
+    'hudson.scm.SCM.Tag',
+    'hudson.model.Item.Discover',
+    'hudson.model.Hudson.Read',
+    'hudson.model.Item.Workspace',
+    'hudson.model.Computer.Provision',
+    'hudson.model.View.Read',
+    'org.jenkins.plugins.lockableresources.LockableResourcesManager.View',
+    'hudson.model.Item.Delete',
+    'com.cloudbees.plugins.credentials.CredentialsProvider.Create',
+    'hudson.model.Computer.Disconnect',
+    'hudson.model.Run.Artifacts',
+    'com.cloudbees.plugins.credentials.CredentialsProvider.UseItem',
+    'org.jenkins.plugins.lockableresources.LockableResourcesManager.Reserve'];
+
+  expect(JSON.stringify(JenkinsMainNode.rolePermissions()) === JSON.stringify(rolePermissions)).toBeTruthy();
+});
+
+test('Verify initial admin users for when OIDC is enabled', async () => {
+  expect(JenkinsMainNode.admins()).toBeInstanceOf(Array);
+
+  const admins : string[] = [
+    'admin',
+    'gaiksaya',
+    'zhujiaxi',
+    'abhng',
+    'bbarani',
+    'zelinhao',
+  ];
+
+  expect(JSON.stringify(JenkinsMainNode.admins()) === JSON.stringify(admins)).toBeTruthy();
 });
 
 test('createPluginInstallCommands breaks apart many plugins', async () => {

--- a/test/compute/jenkins-main-node.test.ts
+++ b/test/compute/jenkins-main-node.test.ts
@@ -23,7 +23,7 @@ describe('JenkinsMainNode Config Elements', () => {
 
   // THEN
   test('Config elements expected counts', async () => {
-    expect(configElements.filter((e) => e.elementType === 'COMMAND')).toHaveLength(37);
+    expect(configElements.filter((e) => e.elementType === 'COMMAND')).toHaveLength(36);
     expect(configElements.filter((e) => e.elementType === 'PACKAGE')).toHaveLength(14);
     expect(configElements.filter((e) => e.elementType === 'FILE')).toHaveLength(3);
   });
@@ -31,97 +31,6 @@ describe('JenkinsMainNode Config Elements', () => {
   test('Does not use service in config elements', async () => {
     expect(configElements.filter((e) => e.elementType === 'SERVICE')).toHaveLength(0);
   });
-});
-
-test('Verify config.xml fields for jenkins OIDC', async () => {
-  expect(JenkinsMainNode.oidcConfigFields()).toBeInstanceOf(Array);
-
-  const oidcConfigFields : string[][] = [['clientId', 'replace'],
-    ['clientSecret', 'replace'],
-    ['wellKnownOpenIDConfigurationUrl', 'replace'],
-    ['tokenServerUrl', 'replace'],
-    ['authorizationServerUrl', 'replace'],
-    ['userInfoServerUrl', 'replace'],
-    ['userNameField', 'sub'],
-    ['scopes', 'openid'],
-    ['disableSslVerification', 'false'],
-    ['logoutFromOpenidProvider', 'true'],
-    ['postLogoutRedirectUrl', ''],
-    ['escapeHatchEnabled', 'false'],
-    ['escapeHatchSecret', 'random']];
-
-  expect(JSON.stringify(JenkinsMainNode.oidcConfigFields()) === JSON.stringify(oidcConfigFields)).toBeTruthy();
-});
-
-test('Verify config.xml fields for jenkins Role Based Auth', async () => {
-  expect(JenkinsMainNode.rolePermissions()).toBeInstanceOf(Array);
-
-  const rolePermissions : string[] = ['hudson.model.Hudson.Manage',
-    'hudson.model.Computer.Connect',
-    'hudson.model.Hudson.UploadPlugins',
-    'com.synopsys.arc.jenkins.plugins.ownership.OwnershipPlugin.Jobs',
-    'hudson.model.Hudson.ConfigureUpdateCenter',
-    'hudson.model.Hudson.Administer',
-    'hudson.model.Item.Cancel',
-    'com.cloudbees.plugins.credentials.CredentialsProvider.View',
-    'hudson.model.Computer.Delete',
-    'hudson.model.Item.Build',
-    'hudson.plugins.jobConfigHistory.JobConfigHistory.DeleteEntry',
-    'hudson.model.Item.Move',
-    'com.cloudbees.plugins.credentials.CredentialsProvider.Update',
-    'org.jenkins.plugins.lockableresources.LockableResourcesManager.Steal',
-    'hudson.model.Item.Create',
-    'com.cloudbees.plugins.credentials.CredentialsProvider.Delete',
-    'hudson.model.Run.Replay',
-    'hudson.model.Item.WipeOut',
-    'hudson.model.Hudson.RunScripts',
-    'hudson.model.Hudson.SystemRead',
-    'hudson.model.View.Create',
-    'hudson.model.Computer.ExtendedRead',
-    'hudson.model.Computer.Configure',
-    'com.synopsys.arc.jenkins.plugins.ownership.OwnershipPlugin.Nodes',
-    'com.cloudbees.plugins.credentials.CredentialsProvider.UseOwn',
-    'hudson.model.Run.Update',
-    'hudson.model.View.Delete',
-    'hudson.model.Run.Delete',
-    'com.cloudbees.plugins.credentials.CredentialsProvider.ManageDomains',
-    'hudson.model.Computer.Create',
-    'hudson.model.View.Configure',
-    'hudson.model.Computer.Build',
-    'hudson.model.Item.Configure',
-    'hudson.model.Item.Read',
-    'org.jenkins.plugins.lockableresources.LockableResourcesManager.Unlock',
-    'hudson.model.Item.ExtendedRead',
-    'hudson.scm.SCM.Tag',
-    'hudson.model.Item.Discover',
-    'hudson.model.Hudson.Read',
-    'hudson.model.Item.Workspace',
-    'hudson.model.Computer.Provision',
-    'hudson.model.View.Read',
-    'org.jenkins.plugins.lockableresources.LockableResourcesManager.View',
-    'hudson.model.Item.Delete',
-    'com.cloudbees.plugins.credentials.CredentialsProvider.Create',
-    'hudson.model.Computer.Disconnect',
-    'hudson.model.Run.Artifacts',
-    'com.cloudbees.plugins.credentials.CredentialsProvider.UseItem',
-    'org.jenkins.plugins.lockableresources.LockableResourcesManager.Reserve'];
-
-  expect(JSON.stringify(JenkinsMainNode.rolePermissions()) === JSON.stringify(rolePermissions)).toBeTruthy();
-});
-
-test('Verify initial admin users for when OIDC is enabled', async () => {
-  expect(JenkinsMainNode.admins()).toBeInstanceOf(Array);
-
-  const admins : string[] = [
-    'admin',
-    'gaiksaya',
-    'zhujiaxi',
-    'abhng',
-    'bbarani',
-    'zelinhao',
-  ];
-
-  expect(JSON.stringify(JenkinsMainNode.admins()) === JSON.stringify(admins)).toBeTruthy();
 });
 
 test('createPluginInstallCommands breaks apart many plugins', async () => {


### PR DESCRIPTION
Signed-off-by: Sayali Gaikawad <gaiksaya@amazon.com>

### Description
When OIDC is enabled the user is locked out as no one has admin access now. This PR fixes the issue and gives a set of users admin access.
 
### Issues Resolved
N/A
 
### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
