### PR TITLE
Restructure OIDC element

### DIFF
--- a/test/compute/jenkins-main-node.test.ts
+++ b/test/compute/jenkins-main-node.test.ts
@@ -16,20 +16,32 @@ describe('JenkinsMainNode Config Elements', () => {
     sslCertPrivateKeyContentsArn: 'ARN:CDE',
     sslCertChainArn: 'ARN:DEF',
     useSsl: true,
-  }, {
-    oidcCredArn: 'ARN:DEF',
-    runWithOidc: false,
   });
 
   // THEN
   test('Config elements expected counts', async () => {
-    expect(configElements.filter((e) => e.elementType === 'COMMAND')).toHaveLength(37);
+    expect(configElements.filter((e) => e.elementType === 'COMMAND')).toHaveLength(32);
     expect(configElements.filter((e) => e.elementType === 'PACKAGE')).toHaveLength(14);
     expect(configElements.filter((e) => e.elementType === 'FILE')).toHaveLength(3);
   });
 
   test('Does not use service in config elements', async () => {
     expect(configElements.filter((e) => e.elementType === 'SERVICE')).toHaveLength(0);
+  });
+});
+
+describe('OIDC Config Elements', () => {
+  // WHEN
+  const configOidcElements = JenkinsMainNode.configOidcElements('us-west-2', {
+    oidcCredArn: 'ARN:DEF',
+    runWithOidc: true,
+    adminUsers: ['admin1', 'admin2'],
+  });
+
+  // THEN
+
+  test('OIDC config elements counts', async () => {
+    expect(configOidcElements.filter((e) => e.elementType === 'COMMAND')).toHaveLength(2);
   });
 });
 


### PR DESCRIPTION
Signed-off-by: Sayali Gaikawad <gaiksaya@amazon.com>

### Description
Once OIDC is active, none of the admin based command lines work. This PR changes the order in which config is added to config.xml file. OIDC will be activated at last once all other config (example: agent node config) is in.
 
### Issues Resolved
[List any issues this PR will resolve]
 
### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
