### PR TITLE
Fix README

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ $aws secretsmanager put-secret-value \
    ```
     {
         "clientId": "example_id",
-        "clientPassword": "example_password",
+        "clientSecret": "example_password",
         "wellKnownOpenIDConfigurationUrl": "https://www.example.com",
         "tokenServerUrl": "https://example.com/token",
         "authorizationServerUrl": "https://example.com/authorize",

--- a/lib/compute/jenkins-main-node.ts
+++ b/lib/compute/jenkins-main-node.ts
@@ -191,8 +191,7 @@ export class JenkinsMainNode {
         ? `mkdir /etc/ssl/private/ && aws --region ${stackRegion} secretsmanager get-secret-value --secret-id ${httpConfigProps.sslCertPrivateKeyContentsArn} --query SecretString --output text  > ${JenkinsMainNode.PRIVATE_KEY_PATH}`
         : 'echo useSsl is false, not creating key file'),
 
-      // Local reverse proxy is used, see design for details
-      // https://quip-amazon.com/jjIKA6tIPQbw/ODFE-Jenkins-Production-Cluster-JPC-High-Level-Design#BeF9CAIwx3k
+      // Local reverse proxy is used
       InitPackage.yum('httpd'),
 
       // Configuration to proxy jenkins on :8080 -> :80
@@ -324,7 +323,7 @@ export class JenkinsMainNode {
       // Commands are fired one after the other but it does not wait for the command to complete.
       // Therefore, sleep 60 seconds to wait for jenkins to start
       // This allows jenkins to generate the secrets files used for auth in jenkins-cli APIs
-      InitCommand.shellCommand('sleep 60'),
+      InitCommand.shellCommand('sleep 65'),
 
       // creating a default  user:password file to use to authenticate the jenkins-cli
       // eslint-disable-next-line max-len
@@ -343,6 +342,7 @@ export class JenkinsMainNode {
       InitCommand.shellCommand('sleep 60'),
 
       InitFile.fromFileInline('/var/lib/jenkins/jenkins.yaml', join(__dirname, '../../resources/jenkins.yaml')),
+
     ];
   }
 


### PR DESCRIPTION
Signed-off-by: Sayali Gaikawad <gaiksaya@amazon.com>

### Description
Due to the wrong key value in README OIDC password was being set as null causing OIDC to fail. This PR fixes this. 
The change in sleep seconds is to trigger a redeploy to internal stack.
 
### Issues Resolved
[List any issues this PR will resolve]
 
### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
