### PR TITLE
Add read-only role for anonymous users

### DIFF
--- a/lib/compute/jenkins-main-node-config.ts
+++ b/lib/compute/jenkins-main-node-config.ts
@@ -6,8 +6,6 @@
  * compatible open source license.
  */
 
-import { JenkinsMainNode } from './jenkins-main-node';
-
 export class JenkinsMainNodeConfig {
   public static oidcConfigFields() : string[][] {
     return [['clientId', 'replace'],
@@ -25,7 +23,7 @@ export class JenkinsMainNodeConfig {
       ['escapeHatchSecret', 'random']];
   }
 
-  public static rolePermissions() : string[] {
+  public static adminRolePermissions() : string[] {
     return ['hudson.model.Hudson.Manage',
       'hudson.model.Computer.Connect',
       'hudson.model.Hudson.UploadPlugins',
@@ -75,5 +73,12 @@ export class JenkinsMainNodeConfig {
       'hudson.model.Run.Artifacts',
       'com.cloudbees.plugins.credentials.CredentialsProvider.UseItem',
       'org.jenkins.plugins.lockableresources.LockableResourcesManager.Reserve'];
+  }
+
+  public static readOnlyRolePermissions(): string[] {
+    return [
+      'hudson.model.Hudson.Read',
+      'hudson.model.Item.Read',
+    ];
   }
 }

--- a/test/compute/jenkins-main-node-config.test.ts
+++ b/test/compute/jenkins-main-node-config.test.ts
@@ -29,8 +29,8 @@ test('Verify config.xml fields for jenkins OIDC', async () => {
   expect(JSON.stringify(JenkinsMainNodeConfig.oidcConfigFields()) === JSON.stringify(oidcConfigFields)).toBeTruthy();
 });
 
-test('Verify config.xml fields for jenkins Role Based Auth', async () => {
-  expect(JenkinsMainNodeConfig.rolePermissions()).toBeInstanceOf(Array);
+test('Verify config.xml fields for jenkins Admin Role', async () => {
+  expect(JenkinsMainNodeConfig.adminRolePermissions()).toBeInstanceOf(Array);
 
   const rolePermissions : string[] = ['hudson.model.Hudson.Manage',
     'hudson.model.Computer.Connect',
@@ -82,7 +82,18 @@ test('Verify config.xml fields for jenkins Role Based Auth', async () => {
     'com.cloudbees.plugins.credentials.CredentialsProvider.UseItem',
     'org.jenkins.plugins.lockableresources.LockableResourcesManager.Reserve'];
 
-  expect(JSON.stringify(JenkinsMainNodeConfig.rolePermissions()) === JSON.stringify(rolePermissions)).toBeTruthy();
+  expect(JSON.stringify(JenkinsMainNodeConfig.adminRolePermissions()) === JSON.stringify(rolePermissions)).toBeTruthy();
+});
+
+test('Verify config.xml fields for jenkins Read-Only Role', async () => {
+  expect(JenkinsMainNodeConfig.readOnlyRolePermissions()).toBeInstanceOf(Array);
+
+  const rolePermissions : string[] = [
+    'hudson.model.Hudson.Read',
+    'hudson.model.Item.Read',
+  ];
+
+  expect(JSON.stringify(JenkinsMainNodeConfig.readOnlyRolePermissions()) === JSON.stringify(rolePermissions)).toBeTruthy();
 });
 
 test('Verify initial admin users for when OIDC is enabled', async () => {

--- a/test/compute/jenkins-main-node.test.ts
+++ b/test/compute/jenkins-main-node.test.ts
@@ -41,7 +41,7 @@ describe('OIDC Config Elements', () => {
   // THEN
 
   test('OIDC config elements counts', async () => {
-    expect(configOidcElements.filter((e) => e.elementType === 'COMMAND')).toHaveLength(2);
+    expect(configOidcElements.filter((e) => e.elementType === 'COMMAND')).toHaveLength(3);
   });
 });
 


### PR DESCRIPTION
Signed-off-by: Sayali Gaikawad <gaiksaya@amazon.com>

### Description
For external users/contributors who are unable to login via OIDC, this change added a readonly permission for `anonymous` users.
 
### Issues Resolved
[List any issues this PR will resolve]
 
### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
