### PR TITLE
update jenkins deployment to use docker on agent nodes

### DIFF
--- a/lib/compute/agent-nodes.ts
+++ b/lib/compute/agent-nodes.ts
@@ -35,7 +35,8 @@ export class AgentNode {
 
   public readonly InitScript: string = 'sudo mkdir -p /var/jenkins/ && sudo chown -R ec2-user:ec2-user /var/jenkins '
     + '&& sudo yum install -y java-1.8.0-openjdk cmake python3 python3-pip && sudo yum groupinstall -y \'Development Tools\' '
-    + '&& sudo ln -sfn `which pip3` /usr/bin/pip && pip3 install pipenv && sudo ln -s ~/.local/bin/pipenv /usr/local/bin';
+    + '&& sudo ln -sfn `which pip3` /usr/bin/pip && pip3 install pipenv && sudo ln -s ~/.local/bin/pipenv /usr/local/bin '
+    + '&& sudo amazon-linux-extras install -y docker && sudo service docker start && sudo systemctl enable docker && sudo chmod 666 /var/run/docker.sock ';
 
   constructor(stack: Stack) {
     const key = new KeyPair(stack, 'AgentNode-KeyPair', {

--- a/lib/compute/jenkins-plugins.ts
+++ b/lib/compute/jenkins-plugins.ts
@@ -92,6 +92,7 @@ export class JenkinsPlugins {
       'ownership',
       'pam-auth',
       'parameterized-scheduler',
+      'pipeline-aws',
       'pipeline-build-step',
       'pipeline-github-lib',
       'pipeline-graph-analysis',


### PR DESCRIPTION
Signed-off-by: Abhinav Gupta <abhng@amazon.com>

### Description
ci can now run docker agent nodes and withAws commands
 
### Issues Resolved
https://github.com/opensearch-project/opensearch-ci/issues/79
 
### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
