### PR TITLE
Remove multi-scm plugin

### DIFF
--- a/lib/compute/jenkins-main-node.ts
+++ b/lib/compute/jenkins-main-node.ts
@@ -350,7 +350,7 @@ export class JenkinsMainNode {
       // Commands are fired one after the other but it does not wait for the command to complete.
       // Therefore, sleep 60 seconds to wait for jenkins to start
       // This allows jenkins to generate the secrets files used for auth in jenkins-cli APIs
-      InitCommand.shellCommand('sleep 65'),
+      InitCommand.shellCommand('sleep 60'),
 
       // creating a default  user:password file to use to authenticate the jenkins-cli
       // eslint-disable-next-line max-len

--- a/lib/compute/jenkins-plugins.ts
+++ b/lib/compute/jenkins-plugins.ts
@@ -84,7 +84,6 @@ export class JenkinsPlugins {
     'maven-plugin:3.8.1',
     'momentjs:1.1.1',
     'multi-branch-project-plugin:0.7',
-    'multiple-scms:0.6',
     'node-iterator-api:1.5.1',
     'nodelabelparameter:1.9.2',
     'nvm-wrapper:0.1.7',
@@ -150,6 +149,6 @@ export class JenkinsPlugins {
     'workflow-step-api:622.vb_8e7c15b_c95a_',
     'workflow-support:3.8',
     'ws-cleanup:0.40',
-    'xml-job-to-job-dsl:0.1.13'
-    ];
+    'xml-job-to-job-dsl:0.1.13',
+  ];
 }


### PR DESCRIPTION
Signed-off-by: Sayali Gaikawad <gaiksaya@amazon.com>

### Description
The multi-SCM plugin is deprecated and is causing null pointer errors in few actions in Jenkins. Removing this plugin as it is not required anymore.
https://plugins.jenkins.io/multiple-scms/
 
### Issues Resolved
N/A
 
### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
