### PR TITLE
[Agent Nodes] Load jenkins config via yaml

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@ cdk.out
 # excluding intellij Idea files
 *.iml
 .idea/
+.vscode/

--- a/bin/ci-stack.ts
+++ b/bin/ci-stack.ts
@@ -6,7 +6,6 @@
  * compatible open source license.
  */
 
-import 'source-map-support/register';
 import { App, RemovalPolicy } from '@aws-cdk/core';
 import { CIStack } from '../lib/ci-stack';
 import { CIConfigStack } from '../lib/ci-config-stack';

--- a/lib/compute/agent-nodes.ts
+++ b/lib/compute/agent-nodes.ts
@@ -6,207 +6,42 @@
  * compatible open source license.
  */
 
-import { CfnInstanceProfile, ServicePrincipal, Role } from '@aws-cdk/aws-iam';
-import { Fn, Stack, Tags } from '@aws-cdk/core';
-import { KeyPair } from 'cdk-ec2-key-pair';
 import {
-  InitCommand, InitElement, InitFile, InitFileOptions,
+  AmazonLinuxCpuType, AmazonLinuxGeneration, MachineImage,
 } from '@aws-cdk/aws-ec2';
-import { JenkinsMainNode } from './jenkins-main-node';
+import { Stack } from '@aws-cdk/core';
+import { AgentNodeProps } from './agent-node-config';
 
-export interface AgentNodeConfig{
-  amiId : string;
-  ec2CloudName : string;
-  instanceType : string;
-  workerLabelString : string;
-  numberOfExecutors : string;
-  remoteUser : string;
-}
+export class AgentNodes {
+    // Refer: https://docs.aws.amazon.com/AWSJavaSDK/latest/javadoc/com/amazonaws/services/ec2/model/InstanceType.html for instance types
+    readonly AL2_X64: AgentNodeProps;
 
-export interface AgentNodeProps{
-  readonly agentNodeSecurityGroup : string;
-  readonly subnetId : string;
-}
+    readonly AL2_ARM64: AgentNodeProps;
 
-export class AgentNode {
-  public readonly AgentNodeInstanceProfileArn: string;
-
-  public readonly SSHEC2KeySecretId: string;
-
-  public readonly InitScript: string = 'sudo mkdir -p /var/jenkins/ && sudo chown -R ec2-user:ec2-user /var/jenkins '
-    + '&& sudo yum install -y java-1.8.0-openjdk cmake python3 python3-pip && sudo yum groupinstall -y \'Development Tools\' '
-    + '&& sudo ln -sfn `which pip3` /usr/bin/pip && pip3 install pipenv && sudo ln -s ~/.local/bin/pipenv /usr/local/bin '
-    + '&& sudo amazon-linux-extras install -y docker && sudo service docker start && sudo systemctl enable docker && sudo chmod 666 /var/run/docker.sock ';
-
-  constructor(stack: Stack) {
-    const key = new KeyPair(stack, 'AgentNode-KeyPair', {
-      name: 'AgentNodeKeyPair',
-      description: 'KeyPair used by Jenkins Main Node to SSH into Agent Nodes',
-    });
-    Tags.of(key)
-      .add('jenkins:credentials:type', 'sshUserPrivateKey');
-    const AgentNodeRole = new Role(stack, 'JenkinsAgentNodeRole', {
-      assumedBy: new ServicePrincipal('ec2.amazonaws.com'),
-    });
-    const AgentNodeInstanceProfile = new CfnInstanceProfile(stack, 'JenkinsAgentNodeInstanceProfile', { roles: [AgentNodeRole.roleName] });
-    this.AgentNodeInstanceProfileArn = AgentNodeInstanceProfile.attrArn.toString();
-    this.SSHEC2KeySecretId = Fn.join('/', ['ec2-ssh-key', key.keyPairName.toString(), 'private']);
-  }
-
-  public asInitFile(filePath: string, stackConfig: AgentNodeProps, config: AgentNodeConfig, stackRegion: string, options?: InitFileOptions): InitFile {
-    return InitFile.fromString(filePath,
-      `
-    import hudson.model.*
-    import jenkins.model.*
-    import hudson.plugins.ec2.*
-    import com.amazonaws.services.ec2.model.InstanceType
-
-    def instance = Jenkins.getInstance()
-    def init_script = "${this.InitScript}"
-    def instance_profile_arn = "${this.AgentNodeInstanceProfileArn}"
-    def sshKeysASMSecretId = "${this.SSHEC2KeySecretId}"
-
-    // Agent node configuration specific to each node
-    def ec2_cloud_name = "${config.ec2CloudName}"
-    def instance_type = "${config.instanceType}"
-    def worker_label_string = "${config.workerLabelString}"
-    def number_of_executors = "${config.numberOfExecutors}"
-    def remote_user = "${config.remoteUser}"
-    def ami_id = "${config.amiId}"
-
-    // Values that are imported from the stack
-    def region = "${stackRegion}"
-    def security_group = "${stackConfig.agentNodeSecurityGroup.toString()}"
-    def subnet_id = "${stackConfig.subnetId.toString()}"
-    def ec2_tags = [new EC2Tag('Name', 'jenkins-agent-node')]
-    
-    
-    // SlaveTemplate ref: https://github.com/jenkinsci/ec2-plugin/blob/master/src/main/java/hudson/plugins/ec2/SlaveTemplate.java
-    def agent_node_template = new SlaveTemplate(
-      // String ami
-      ami_id,
-      // String zone
-      '',
-      // SpotConfiguration spotConfig
-      null,
-      // String securityGroups
-      security_group,
-      // String remoteFS
-      '/var/jenkins',
-      // InstanceType type
-      InstanceType.fromValue(instance_type),
-      // boolean ebsOptimized
-      false,
-      // String labelString
-      worker_label_string,
-      // Node.Mode mode
-      Node.Mode.NORMAL,
-      // String description
-      'Jenkins Agent Node',
-      // String initScript
-      init_script,
-      // String tmpDir
-      '',
-      // String userData
-      '',
-      // String numExecutors
-      number_of_executors,
-      // String remoteAdmin
-      remote_user,
-      // AMITypeData amiType
-      new UnixData(null, null, null, null),
-      // String jvmopts
-      '',
-      // boolean stopOnTerminate
-      false,
-      // String subnetId
-      subnet_id,
-      // List<EC2Tag> tags
-      ec2_tags,
-      // String idleTerminationMinutes
-      '30',
-      //int minimumNumberOfInstances,
-      0,
-      //int minimumNumberOfSpareInstances,
-      1,
-      // String instanceCapStr
-      '20',
-      // String iamInstanceProfile
-      instance_profile_arn,
-      //  boolean deleteRootOnTermination
-      true,
-      // boolean useEphemeralDevices
-      false,
-      // String launchTimeoutStr
-      '1800',
-      // boolean associatePublicIp
-      false,
-      // String customDeviceMapping
-      '/dev/xvda=:100:true:::encrypted',
-      // boolean connectBySSHProcess
-      false,
-      // boolean monitoring,
-      true,
-      // boolean t2Unlimited,
-      false,
-      // ConnectionStrategy connectionStrategy,
-      null,
-      // int maxTotalUses,
-      -1,
-      // List<? extends NodeProperty<?>> nodeProperties,
-      null,
-      // HostKeyVerificationStrategyEnum hostKeyVerificationStrategy,
-      HostKeyVerificationStrategyEnum.OFF,
-      //Tenancy tenancy,
-      Tenancy.Default,
-      //EbsEncryptRootVolume ebsEncryptRootVolume,
-      EbsEncryptRootVolume.ENCRYPTED,
-    )
-    
-    // AmazonEC2Cloud ref: https://github.com/jenkinsci/ec2-plugin/blob/master/src/main/java/hudson/plugins/ec2/AmazonEC2Cloud.java
-    def new_cloud = new AmazonEC2Cloud(
-      // String cloudName
-      ec2_cloud_name,
-      // boolean useInstanceProfileForCredentials
-      true,
-      // String credentialsId
-      '',
-      // String region
-      region,
-      // String privateKey
-      null,
-      // String sshKeysCredentialsId
-      sshKeysASMSecretId,
-      // String instanceCapStr
-      "10",
-      // List<? extends SlaveTemplate> templates
-      [agent_node_template],
-      // String roleArn: We have instance profile with a role attached to the instance
-      '',
-      // String roleSessionName
-      ''
-    )
-
-    instance.clouds.add(new_cloud)
-    instance.save()`);
-  }
-
-  public configElements(stackRegion: string, agentNodeProps: AgentNodeProps, al2x64AgentNodeConfig: AgentNodeConfig,
-    al2arm64AgentNodeConfig: AgentNodeConfig): InitElement[] {
-    return [
-    // Create groovy script that holds the agent Node config for EC2 plugin ref:https://gist.github.com/vrivellino/97954495938e38421ba4504049fd44ea
-      this.asInitFile(`/${al2x64AgentNodeConfig.ec2CloudName}.groovy`, agentNodeProps, al2x64AgentNodeConfig, stackRegion),
-
-      // Run the above groovy script
-      // eslint-disable-next-line max-len
-      InitCommand.shellCommand(`java -jar /jenkins-cli.jar -s http://localhost:8080 -auth @${JenkinsMainNode.JENKINS_DEFAULT_ID_PASS_PATH} groovy = < /${al2x64AgentNodeConfig.ec2CloudName}.groovy`),
-
-      // Generating groovy script for arm64 Agent Node
-      this.asInitFile(`/${al2arm64AgentNodeConfig.ec2CloudName}.groovy`, agentNodeProps, al2arm64AgentNodeConfig, stackRegion),
-
-      // Run the arm64 groovy script to set up ARM64 agent
-      // eslint-disable-next-line max-len
-      InitCommand.shellCommand(`java -jar /jenkins-cli.jar -s http://localhost:8080 -auth @${JenkinsMainNode.JENKINS_DEFAULT_ID_PASS_PATH} groovy = < /${al2arm64AgentNodeConfig.ec2CloudName}.groovy`),
-    ];
-  }
+    constructor(stack: Stack) {
+      this.AL2_X64 = {
+        workerLabelString: 'AL2-X64',
+        instanceType: 'C54xlarge',
+        remoteUser: 'ec2-user',
+        amiId: MachineImage.latestAmazonLinux({
+          generation: AmazonLinuxGeneration.AMAZON_LINUX_2,
+          cpuType: AmazonLinuxCpuType.X86_64,
+        }).getImage(stack).imageId.toString(),
+        initScript: 'sudo mkdir -p /var/jenkins/ && sudo chown -R ec2-user:ec2-user /var/jenkins &&'
+        + ' sudo yum install -y java-1.8.0-openjdk cmake python3 python3-pip python3-devel && sudo yum groupinstall -y "Development Tools" &&'
+        + ' sudo ln -sfn `which pip3` /usr/bin/pip && pip3 install pipenv && sudo ln -s ~/.local/bin/pipenv /usr/local/bin',
+      };
+      this.AL2_ARM64 = {
+        workerLabelString: 'AL2-ARM64',
+        instanceType: 'C6g4xlarge',
+        remoteUser: 'ec2-user',
+        amiId: MachineImage.latestAmazonLinux({
+          generation: AmazonLinuxGeneration.AMAZON_LINUX_2,
+          cpuType: AmazonLinuxCpuType.ARM_64,
+        }).getImage(stack).imageId.toString(),
+        initScript: 'sudo mkdir -p /var/jenkins/ && sudo chown -R ec2-user:ec2-user /var/jenkins &&'
+        + ' sudo yum install -y java-1.8.0-openjdk cmake python3 python3-pip python3-devel && sudo yum groupinstall -y "Development Tools" &&'
+        + ' sudo ln -sfn `which pip3` /usr/bin/pip && pip3 install pipenv && sudo ln -s ~/.local/bin/pipenv /usr/local/bin',
+      };
+    }
 }

--- a/test/compute/oidc-config.test.ts
+++ b/test/compute/oidc-config.test.ts
@@ -8,6 +8,7 @@
 
 import { readFileSync } from 'fs';
 import { load } from 'js-yaml';
+import { JenkinsMainNode } from '../../lib/compute/jenkins-main-node';
 import { OidcConfig } from '../../lib/compute/oidc-config';
 
 describe('JenkinsMainNode Config Elements', () => {
@@ -30,7 +31,8 @@ describe('JenkinsMainNode Config Elements', () => {
     userNameField: 'userNameField',
   };
   const admins = ['admin1', 'admin2'];
-  OidcConfig.addOidcConfigToJenkinsYaml(testYaml, admins);
+  const jenkinsYaml = load(readFileSync(JenkinsMainNode.BASE_JENKINS_YAML_PATH, 'utf-8'));
+  OidcConfig.addOidcConfigToJenkinsYaml(jenkinsYaml, admins);
   const yml: any = load(readFileSync(testYaml, 'utf-8'));
 
   // THEN


### PR DESCRIPTION
Signed-off-by: Sayali Gaikawad <gaiksaya@amazon.com>

### Description
This change adds the functionality to load agent nodes configuration via jenkins.yaml

### Testing
Tested by deploying the stack using all combinations(ssl/oidc: true/false) to make sure none of the other functionality breaks.
 
### Issues Resolved
Resolves #88 
 
### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
