### PR TITLE
Fix readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,7 +120,7 @@ $aws secretsmanager put-secret-value \
 1. Add additional `adminUsers` for role based authentication according to your needs, see [CIStackProps](./lib/ci-stack.ts) for details.
 1. Run with parameter with one of the following (refer [this](#ssl-configuration) for value of `useSsL`) -
    1. `npm run cdk deploy OpenSearch-CI-Dev -- -c runWithOidc=true -c useSsl=true` or,
-   1. `cdk deploy OpenSearch-OpenSearch-CI-Dev -c runWithOidc=true -c useSsl=true`
+   1. `cdk deploy OpenSearch-CI-Dev -c runWithOidc=true -c useSsl=true`
 1. Continue with [next steps](#dev-deployment)
 
 ### Troubleshooting

--- a/lib/compute/jenkins-main-node.ts
+++ b/lib/compute/jenkins-main-node.ts
@@ -375,7 +375,7 @@ export class JenkinsMainNode {
 
       // Commands are fired one after the other but it does not wait for the command to complete.
       // Therefore, sleep 60 seconds to wait for plugins to install and jenkins to start which is required for the next step
-      InitCommand.shellCommand('sleep 60'),
+      InitCommand.shellCommand('sleep 65'),
 
       InitFile.fromFileInline('/var/lib/jenkins/initial_jenkins.yaml', jenkinsyaml),
 


### PR DESCRIPTION
Signed-off-by: Sayali Gaikawad <gaiksaya@amazon.com>

### Description
Fixes documentation. 
Change in timeout is to trigger internal deployment. There was a hiccup in jenkins installation. Looks like a transient issue. This will retrigger the redeployment.
 
### Issues Resolved
[List any issues this PR will resolve]
 
### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
