### PR TITLE
Fix typo and keep previous values for OIDC

### DIFF
--- a/lib/compute/oidc-config.ts
+++ b/lib/compute/oidc-config.ts
@@ -55,7 +55,7 @@ export class OidcConfig {
     public static addOidcConfigToJenkinsYaml(yamlObject: any, admins?: string[]): any {
       const jenkinsYaml: any = yamlObject;
       let adminUsers: string[] = ['admin'];
-      const readOnlyUsers: string[] = ['anyonomous'];
+      const readOnlyUsers: string[] = ['anonymous'];
 
       if (admins) {
         adminUsers = adminUsers.concat(admins);
@@ -70,11 +70,8 @@ export class OidcConfig {
           tokenServerUrl: 'tokenServerUrl',
           userInfoServerUrl: 'userInfoServerUrl',
           disableSslVerification: false,
-          userNameField: 'userNameField',
-          fullNameFieldName: 'fullNameFieldName',
+          userNameField: 'sub',
           escapeHatchEnabled: false,
-          escapeHatchGroup: 'escapeHatchGroup',
-          escapeHatchUsername: 'escapeHatchUsername',
           logoutFromOpenidProvider: true,
           postLogoutRedirectUrl: '',
           scopes: 'openid',


### PR DESCRIPTION
Signed-off-by: Sayali Gaikawad <gaiksaya@amazon.com>

### Description
Looking https://github.com/abhinavGupta16/opensearch-ci/blob/6778f6ab19d5e725627704b2b1eba8aa99637b1c/lib/compute/jenkins-main-node.ts#L354-L366 keeping only those values and also fixing the typo for anonymous




 
### Issues Resolved
[List any issues this PR will resolve]
 
### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
