### PR TITLE
Rename strict mode to ignoreResourcesFailures and remove jq installation

### DIFF
--- a/lib/ci-stack.ts
+++ b/lib/ci-stack.ts
@@ -31,7 +31,7 @@ export interface CIStackProps extends StackProps {
   /** Should an OIDC provider be installed on Jenkins. */
   readonly runWithOidc?: boolean;
   /** Additional verification during deployment and resource startup. */
-  readonly strictMode?: boolean;
+  readonly ignoreResourcesFailures?: boolean;
   /** Account to deploy your ECR Assets on */
   readonly ecrAccountId?: string;
   /** Users with admin access during initial deployment */
@@ -100,7 +100,7 @@ export class CIStack extends Stack {
       oidcCredArn: importedOidcConfigValuesSecretBucketValue.toString(),
       useSsl,
       runWithOidc,
-      failOnCloudInitError: props?.strictMode,
+      failOnCloudInitError: props?.ignoreResourcesFailures,
       ecrAccountId: props.ecrAccountId ?? Stack.of(this).account,
       adminUsers: props?.adminUsers,
       agentNodeSecurityGroup: securityGroups.agentNodeSG.securityGroupId,

--- a/lib/compute/jenkins-main-node.ts
+++ b/lib/compute/jenkins-main-node.ts
@@ -190,7 +190,6 @@ export class JenkinsMainNode {
       InitPackage.yum('wget'),
       InitPackage.yum('unzip'),
       InitPackage.yum('tar'),
-      InitPackage.yum('jq'),
       InitPackage.yum('python3'),
       InitPackage.yum('python3-pip.noarch'),
       InitPackage.yum('git'),

--- a/lib/compute/oidc-config.ts
+++ b/lib/compute/oidc-config.ts
@@ -75,7 +75,7 @@ export class OidcConfig {
           logoutFromOpenidProvider: true,
           postLogoutRedirectUrl: '',
           scopes: 'openid',
-          escapeHatchSecret: 'random'
+          escapeHatchSecret: 'random',
         },
       };
       const rolesAndPermissions: { [x: string]: any; } = {

--- a/test/compute/jenkins-main-node.test.ts
+++ b/test/compute/jenkins-main-node.test.ts
@@ -24,7 +24,7 @@ describe('JenkinsMainNode Config Elements', () => {
   // THEN
   test('Config elements expected counts', async () => {
     expect(configElements.filter((e) => e.elementType === 'COMMAND')).toHaveLength(36);
-    expect(configElements.filter((e) => e.elementType === 'PACKAGE')).toHaveLength(14);
+    expect(configElements.filter((e) => e.elementType === 'PACKAGE')).toHaveLength(13);
     expect(configElements.filter((e) => e.elementType === 'FILE')).toHaveLength(3);
   });
 


### PR DESCRIPTION
Signed-off-by: Sayali Gaikawad <gaiksaya@amazon.com>

### Description
Strict Mode was not doing what it says, when user was setting `strictMode: true` in reality, the error were ignored (during init commands). This PR fixes the words to better understand the functionality behind it.
Also removed jq installation as it is not used anywhere
 
### Issues Resolved
[List any issues this PR will resolve]
 
### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
