### PR TITLE
Few additions to secure jenkins and add relevant packages

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ OpenSearch Continuous Integration is an open source CI system for OpenSearch and
    
    `npm run cdk deploy OpenSearch-CI-Dev -- -c useSsl=false -c runWithOidc=false`
  
-1. Jenkins logs in directly as admin. You do need any credentials to log into.
+1. When OIDC is disabled, this set up will enforce the user to secure jenkins by adding first admin user on deployment. Create admin user and password, fill in all other details like name and email id to start using jenkins.
 1. Go to the `OpenSearch-CI-Dev.JenkinsExternalLoadBalancerDns` url returned by CDK output to access the jenkins host.
 1. If you want to destroy the stack make sure you delete the agent nodes manually (via jenkins UI or AWS console) so that shared resources (like vpc, security groups, etc) can be deleted.
 

--- a/lib/compute/jenkins-main-node.ts
+++ b/lib/compute/jenkins-main-node.ts
@@ -225,6 +225,7 @@ export class JenkinsMainNode {
       InitPackage.yum('python3'),
       InitPackage.yum('python3-pip.noarch'),
       InitCommand.shellCommand('pip3 install docker-compose && ln -s /usr/local/bin/docker-compose /usr/bin/docker-compose'),
+      InitCommand.shellCommand('pip3 install botocore'),
       // eslint-disable-next-line max-len
       InitCommand.shellCommand('sudo wget -nv https://github.com/mikefarah/yq/releases/download/v4.22.1/yq_linux_amd64 -O /usr/bin/yq && sudo chmod +x /usr/bin/yq'),
 
@@ -358,8 +359,8 @@ export class JenkinsMainNode {
       InitCommand.shellCommand('systemctl start docker && docker-compose up -d'),
 
       // Commands are fired one after the other but it does not wait for the command to complete.
-      // Therefore, sleep 60 seconds to wait for jenkins to start
-      InitCommand.shellCommand('sleep 60'),
+      // Therefore, sleep 90 seconds to wait for jenkins to start
+      InitCommand.shellCommand('sleep 90'),
 
       // Download jenkins-cli from the local machine
       InitCommand.shellCommand('wget -O "jenkins-cli.jar" http://localhost:8080/jnlpJars/jenkins-cli.jar'),

--- a/resources/baseJenkins.yaml
+++ b/resources/baseJenkins.yaml
@@ -20,6 +20,18 @@ jenkins:
   remotingSecurity:
     enabled: true
   scmCheckoutRetryCount: 0
+  securityRealm:
+    local:
+      allowsSignup: false
+      enableCaptcha: false
+      users:
+      - id: "admin"
+        name: "admin"
+        properties:
+        - "apiToken"
+        - preferredProvider:
+            providerId: "default"
+        - "loginDetailsProperty"
   slaveAgentPort: 50000
   updateCenter:
     sites:

--- a/test/compute/jenkins-main-node.test.ts
+++ b/test/compute/jenkins-main-node.test.ts
@@ -25,7 +25,7 @@ describe('JenkinsMainNode Config Elements', () => {
 
   // THEN
   test('Config elements expected counts', async () => {
-    expect(configElements.filter((e) => e.elementType === 'COMMAND')).toHaveLength(16);
+    expect(configElements.filter((e) => e.elementType === 'COMMAND')).toHaveLength(17);
     expect(configElements.filter((e) => e.elementType === 'PACKAGE')).toHaveLength(10);
     expect(configElements.filter((e) => e.elementType === 'FILE')).toHaveLength(4);
   });


### PR DESCRIPTION
Signed-off-by: Sayali Gaikawad <gaiksaya@amazon.com>

### Description

- This change helps to secure jenkins by creating first admin user.
- Also installs boto3 which is required for mount point look ups by EFS.
- Increased sleep time to let jenkins come up incase there is some delay.

 
### Issues Resolved
[List any issues this PR will resolve]
 
### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
