### PR TITLE
Fix EFS permissions, logging and init commands

### DIFF
--- a/lib/compute/jenkins-main-node.ts
+++ b/lib/compute/jenkins-main-node.ts
@@ -196,6 +196,9 @@ export class JenkinsMainNode {
             'secretsmanager:GetSecretValue',
             'secretsmanager:ListSecrets',
             'sts:AssumeRole',
+            'elasticfilesystem:DescribeFileSystems',
+            'elasticfilesystem:DescribeMountTargets',
+            'ec2:DescribeAvailabilityZones',
           ],
           resources: ['*'],
         })],
@@ -364,7 +367,8 @@ export class JenkinsMainNode {
       InitCommand.shellCommand('sleep 90'),
 
       // Download jenkins-cli from the local machine
-      InitCommand.shellCommand('wget -O "jenkins-cli.jar" http://localhost:8080/jnlpJars/jenkins-cli.jar'),
+      InitCommand.shellCommand('until $(curl --output /dev/null --silent --head --fail http://localhost:8080); do sleep 5; done &&'
+      +' wget -O "jenkins-cli.jar" http://localhost:8080/jnlpJars/jenkins-cli.jar'),
 
       InitFile.fromFileInline('/initial_jenkins.yaml', jenkinsyaml),
 
@@ -376,6 +380,8 @@ export class JenkinsMainNode {
         // eslint-disable-next-line max-len
         + ' for i in $varkeys; do newvalue=`echo $var | yq .$i` && myenv=$newvalue i=$i yq -i \'.jenkins.securityRealm.oic.[env(i)]=env(myenv)\' /initial_jenkins.yaml ; done'
         : 'echo No changes made to initial_jenkins.yaml with respect to OIDC'),
+
+      InitCommand.shellCommand('sleep 30'),
 
       // Reload configuration via Jenkins.yaml
       InitCommand.shellCommand('cp /initial_jenkins.yaml /var/lib/jenkins/jenkins.yaml &&'

--- a/resources/baseJenkins.yaml
+++ b/resources/baseJenkins.yaml
@@ -17,8 +17,6 @@ jenkins:
       name: "all"
   projectNamingStrategy: "standard"
   quietPeriod: 5
-  remotingSecurity:
-    enabled: true
   scmCheckoutRetryCount: 0
   securityRealm:
     local:

--- a/resources/docker-compose.yml
+++ b/resources/docker-compose.yml
@@ -3,6 +3,7 @@ services:
   jenkins:
     image: opensearchstaging/jenkins:latest
     privileged: true
+    tty: true
     user: root
     ports:
       - 8080:8080

--- a/test/compute/jenkins-main-node.test.ts
+++ b/test/compute/jenkins-main-node.test.ts
@@ -25,7 +25,7 @@ describe('JenkinsMainNode Config Elements', () => {
 
   // THEN
   test('Config elements expected counts', async () => {
-    expect(configElements.filter((e) => e.elementType === 'COMMAND')).toHaveLength(18);
+    expect(configElements.filter((e) => e.elementType === 'COMMAND')).toHaveLength(19);
     expect(configElements.filter((e) => e.elementType === 'PACKAGE')).toHaveLength(10);
     expect(configElements.filter((e) => e.elementType === 'FILE')).toHaveLength(4);
   });


### PR DESCRIPTION
Signed-off-by: Sayali Gaikawad <gaiksaya@amazon.com>

### Description
- Add additional permission for EFS mount points look up
- Fix logging for docker compose
- Add conditional init commands to check jenkins availability

### Issues Resolved
_List any issues this PR will resolve, e.g. Closes [...]._ 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
