### PR TITLE
changed variable scope to instance level

### DIFF
--- a/lib/ci-stack.ts
+++ b/lib/ci-stack.ts
@@ -41,6 +41,8 @@ export interface CIStackProps extends StackProps {
 }
 
 export class CIStack extends Stack {
+  public readonly monitoring: JenkinsMonitoring;
+
   constructor(scope: Construct, id: string, props: CIStackProps) {
     super(scope, id, props);
 
@@ -121,7 +123,7 @@ export class CIStack extends Stack {
       useSsl,
     });
 
-    const monitoring = new JenkinsMonitoring(this, externalLoadBalancer, mainJenkinsNode);
+    this.monitoring = new JenkinsMonitoring(this, externalLoadBalancer, mainJenkinsNode);
 
     if (additionalCommandsContext.toString() !== 'undefined') {
       new RunAdditionalCommands(this, additionalCommandsContext.toString());

--- a/lib/compute/jenkins-main-node.ts
+++ b/lib/compute/jenkins-main-node.ts
@@ -368,7 +368,7 @@ export class JenkinsMainNode {
 
       // Download jenkins-cli from the local machine
       InitCommand.shellCommand('until $(curl --output /dev/null --silent --head --fail http://localhost:8080); do sleep 5; done &&'
-      +' wget -O "jenkins-cli.jar" http://localhost:8080/jnlpJars/jenkins-cli.jar'),
+      + ' wget -O "jenkins-cli.jar" http://localhost:8080/jnlpJars/jenkins-cli.jar'),
 
       InitFile.fromFileInline('/initial_jenkins.yaml', jenkinsyaml),
 


### PR DESCRIPTION
### Description
Updated monitoring stack's variable scope to instance level in order to be used by consuming packages for various use-cases, e.g., using CW Alarms to create monitors using 3P tools. 

### Issues Resolved
Related to meta issue #2 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
