### PR TITLE
Added Managed SSM Policy to Agent instance role

### DIFF
--- a/lib/compute/agent-node-config.ts
+++ b/lib/compute/agent-node-config.ts
@@ -6,7 +6,7 @@
  * compatible open source license.
  */
 
-import { CfnInstanceProfile, ServicePrincipal, Role } from '@aws-cdk/aws-iam';
+import { CfnInstanceProfile, ServicePrincipal, Role, ManagedPolicy } from '@aws-cdk/aws-iam';
 import { Fn, Stack, Tags } from '@aws-cdk/core';
 import { KeyPair } from 'cdk-ec2-key-pair';
 import { readFileSync } from 'fs';
@@ -44,6 +44,7 @@ export class AgentNodeConfig {
     const AgentNodeRole = new Role(stack, 'JenkinsAgentNodeRole', {
       assumedBy: new ServicePrincipal('ec2.amazonaws.com'),
     });
+    AgentNodeRole.addManagedPolicy(ManagedPolicy.fromAwsManagedPolicyName('AmazonSSMManagedInstanceCore'));
     const AgentNodeInstanceProfile = new CfnInstanceProfile(stack, 'JenkinsAgentNodeInstanceProfile', { roles: [AgentNodeRole.roleName] });
     this.AgentNodeInstanceProfileArn = AgentNodeInstanceProfile.attrArn.toString();
     this.SSHEC2KeySecretId = Fn.join('/', ['ec2-ssh-key', key.keyPairName.toString(), 'private']);


### PR DESCRIPTION
Signed-off-by: Rishabh Singh <sngri@amazon.com>

### Description
Currently the role attached to Jenkins agent EC2 node does not have any policy associated with it. This PR adds managed SSM Policy to the instance role. This policy is required to run bare minimum access to make sure the instance is reporting to internal audit tool and helps doing patch baselining.

### Issues Resolved
#116 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
