### PR TITLE
use jenkins-2.332.3 jdk8 base image

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -26,4 +26,4 @@ jobs:
           platforms: linux/amd64,linux/arm64
           context: "{{defaultContext}}:docker"
           push: true
-          tags: opensearchstaging/jenkins:2.332.3-lts,opensearchstaging/jenkins:latest
+          tags: opensearchstaging/jenkins:2.332.3-lts-jdk8,opensearchstaging/jenkins:latest

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM jenkins/jenkins:2.332.3-lts
+FROM jenkins/jenkins:2.332.3-lts-jdk8
 LABEL maintainer="OpenSearch"
 ENV JAVA_OPTS -Djenkins.install.runSetupWizard=false
 COPY plugins.txt plugins.txt

--- a/resources/docker-compose.yml
+++ b/resources/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '3.8'
 services:
   jenkins:
-    image: opensearchstaging/jenkins:2.332.3-lts
+    image: opensearchstaging/jenkins:2.332.3-lts-jdk8
     privileged: true
     tty: true
     user: root


### PR DESCRIPTION
Signed-off-by: Rishabh Singh <sngri@amazon.com>

### Description
This PR adds support to use `jenkins/jenkins:2.332.3-lts-jdk8` as base image instead of `jenkins/jenkins:2.332.3-lts` which is jdk11 based image. A few aws-java-sdk functions are not supported by jdk9+ and are only supported till jdk8. 

### Issues Resolved


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
