### PR TITLE
Add markup formatter as safe/html disable syntax highlighting to allow html

### DIFF
--- a/resources/baseJenkins.yaml
+++ b/resources/baseJenkins.yaml
@@ -8,7 +8,9 @@ jenkins:
   disableRememberMe: false
   labelAtoms:
   - name: "built-in"
-  markupFormatter: "plainText"
+  markupFormatter:
+    rawHtml:
+      disableSyntaxHighlighting: true
   mode: NORMAL
   myViewsTabBar: "standard"
   numExecutors: 2


### PR DESCRIPTION


Signed-off-by: Peter Zhu <zhujiaxi@amazon.com>

### Description
Add markup formatter as safe/html disable syntax highlighting to allow html

### Issues Resolved
Part of https://github.com/opensearch-project/opensearch-build/issues/851

* Settings:
![image](https://user-images.githubusercontent.com/65193828/173473291-95bde232-f868-4af0-b152-095e20ac6fdd.png)

* Before:
![image](https://user-images.githubusercontent.com/65193828/173473300-fec5fde5-f419-4676-9923-50aecdc26814.png)

* After:
![image](https://user-images.githubusercontent.com/65193828/173473362-50aa3767-4086-4da6-8f52-d60d81475d31.png)



By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
