### PR TITLE
Set cache to false for aws secret manager plugin

### DIFF
--- a/resources/baseJenkins.yaml
+++ b/resources/baseJenkins.yaml
@@ -60,6 +60,10 @@ unclassified:
   audit-trail:
     logBuildCause: true
     pattern: ".*/(?:configSubmit|doDelete|postBuildResult|enable|disable|cancelQueue|stop|toggleLogKeep|doWipeOutWorkspace|createItem|createView|toggleOffline|cancelQuietDown|quietDown|restart|exit|safeExit)/?.*"
+  awsCredentialsProvider:
+    cache: false
+    client:
+      credentialsProvider: "default"
   buildDiscarders:
     configuredBuildDiscarders:
     - "jobBuildDiscarder"


### PR DESCRIPTION
Signed-off-by: Peter Zhu <zhujiaxi@amazon.com>

### Description
Set cache to false for aws secret manager plugin

### Issues Resolved


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
