### PR TITLE
Move env variabled to yaml

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,11 +120,11 @@ This will create an EFS (Elastic File System) and mount it on `/var/lib/jenkins`
 #### Add environment variables
 Users can add global level environment variables using configuration as code as follows:
 
-Update the `envVarsFilePath` property in `ciSettings` to the file path containing all environment variables in the form of key:value pair. See [CIStackProps](./lib/ci-stack.ts) for details.
+Update the `envVarsFilePath` property in `ciSettings` to the *yaml* file path containing all environment variables in the form of key:value pair. See [CIStackProps](./lib/ci-stack.ts) for details.
 
-Example: See [env.txt](./test/data/env.txt)
+Example: See [env.txt](./test/data/env.yaml)
 ```
-envVarsFilePath = 'test/data/env.txt'
+envVarsFilePath = 'test/data/env.yaml'
 ```
 
 #### Assume role

--- a/lib/compute/env-config.ts
+++ b/lib/compute/env-config.ts
@@ -1,4 +1,5 @@
 import { readFileSync } from 'fs';
+import { load } from 'js-yaml';
 
 /**
  * SPDX-License-Identifier: Apache-2.0
@@ -22,13 +23,9 @@ export class EnvConfig {
   public static addEnvConfigToJenkinsYaml(yamlObject: any, envVarsFilePath: string): any {
     const jenkinsYaml: any = yamlObject;
     const envArray: Env[] = [];
-    const envFile: string = readFileSync(envVarsFilePath, 'utf-8');
-    const c = envFile.split('\n');
-    c.forEach((item) => {
-      const e = item.split(/:(.*)/s).map((element) => element.trim());
-      envArray.push(new Env(e[0], e[1]));
-    });
+    const envFile: any = load(readFileSync(envVarsFilePath, 'utf-8'));
 
+    Object.keys(envFile).forEach((item) => envArray.push(new Env(item, envFile[item])));
     const newEnvVars: Env[] = envArray;
 
     const envConfig: { [x: string]: any; } = {

--- a/test/compute/env-config.test.ts
+++ b/test/compute/env-config.test.ts
@@ -16,7 +16,7 @@ describe('Env Config', () => {
   const testYaml = 'test/data/test_env.yaml';
   const jenkinsYaml = load(readFileSync(JenkinsMainNode.BASE_JENKINS_YAML_PATH, 'utf-8'));
 
-  const envVarConfig = EnvConfig.addEnvConfigToJenkinsYaml(jenkinsYaml, 'test/data/env.txt');
+  const envVarConfig = EnvConfig.addEnvConfigToJenkinsYaml(jenkinsYaml, 'test/data/env.yaml');
   const newConfig = dump(envVarConfig);
   writeFileSync(testYaml, newConfig, 'utf-8');
 
@@ -27,11 +27,9 @@ describe('Env Config', () => {
       envVars: {
         env: [
           { key: 's3Bucket', value: 'artifactBucket' },
-          { key: 'account', value: '1234' },
-          { key: 'isStaging', value: 'true' },
+          { key: 'account', value: 1234 },
+          { key: 'isStaging', value: true },
           { key: 'url', value: 'https://url.com' },
-          { key: 'nospace', value: 'dummy' },
-          { key: 'multiplespace', value: 'spaces' },
         ],
       },
     };

--- a/test/data/env.txt
+++ b/test/data/env.txt
@@ -1,6 +1,0 @@
-s3Bucket: artifactBucket
-account: 1234
-isStaging: true
-url: https://url.com
-nospace:dummy
-multiplespace:    spaces

--- a/test/data/env.yaml
+++ b/test/data/env.yaml
@@ -1,0 +1,4 @@
+s3Bucket: artifactBucket
+account: 1234
+isStaging: true
+url: https://url.com

--- a/test/data/test_env.yaml
+++ b/test/data/test_env.yaml
@@ -47,15 +47,11 @@ jenkins:
           - key: s3Bucket
             value: artifactBucket
           - key: account
-            value: '1234'
+            value: 1234
           - key: isStaging
-            value: 'true'
+            value: true
           - key: url
             value: https://url.com
-          - key: nospace
-            value: dummy
-          - key: multiplespace
-            value: spaces
 globalCredentialsConfiguration:
   configuration:
     providerFilter: none


### PR DESCRIPTION
Signed-off-by: Sayali Gaikawad <gaiksaya@amazon.com>

### Description
Since env variables are key value pair, accepting them in the form of a yaml file instead of txt file

### Issues Resolved
_List any issues this PR will resolve, e.g. Closes [...]._ 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
