### PR TITLE
Add echo command along with reload config

### DIFF
--- a/lib/compute/jenkins-main-node.ts
+++ b/lib/compute/jenkins-main-node.ts
@@ -390,7 +390,7 @@ export class JenkinsMainNode {
 
       // Reload configuration via Jenkins.yaml
       InitCommand.shellCommand('cp /initial_jenkins.yaml /var/lib/jenkins/jenkins.yaml &&'
-      + ' java -jar /jenkins-cli.jar -s http://localhost:8080 reload-jcasc-configuration'),
+      + ' java -jar /jenkins-cli.jar -s http://localhost:8080 reload-jcasc-configuration || echo Reload command ran here'),
 
     ];
   }


### PR DESCRIPTION
Signed-off-by: Sayali Gaikawad <gaiksaya@amazon.com>

### Description
The last command in the init script script returns error code 255 irrespective of successful run. This happens when you redeploy the stack and already have old config present due to data retention being enabled.
Adding the OR statement runs one of the statement returning the exit code as 0.


### Issues Resolved
_List any issues this PR will resolve, e.g. Closes [...]._ 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
