### PR TITLE
Add jdk14 as it is required by OS 1.x gradle check

### DIFF
--- a/resources/baseJenkins.yaml
+++ b/resources/baseJenkins.yaml
@@ -171,6 +171,12 @@ tool:
           installers:
           - adoptOpenJdkInstaller:
               id: "jdk-11.0.15+10"
+    - name: "jdk-14"
+      properties:
+      - installSource:
+          installers:
+          - adoptOpenJdkInstaller:
+              id: "jdk-14.0.2+12"
     - name: "jdk-17"
       properties:
       - installSource:

--- a/test/data/test_env.yaml
+++ b/test/data/test_env.yaml
@@ -183,6 +183,12 @@ tool:
               installers:
                 - adoptOpenJdkInstaller:
                     id: jdk-11.0.15+10
+      - name: jdk-14
+        properties:
+          - installSource:
+              installers:
+                - adoptOpenJdkInstaller:
+                    id: jdk-14.0.2+12
       - name: jdk-17
         properties:
           - installSource:


### PR DESCRIPTION
Signed-off-by: Peter Zhu <zhujiaxi@amazon.com>

### Description
Add jdk14 as it is required by OS 1.x gradle check

### Issues Resolved
https://github.com/opensearch-project/opensearch-build/issues/851

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
