### PR TITLE
Migrate perf test agent setups to public jenkins

### DIFF
--- a/lib/ci-stack.ts
+++ b/lib/ci-stack.ts
@@ -101,8 +101,8 @@ export class CIStack extends Stack {
     const importedReloadPasswordSecretsArn = Fn.importValue(`${CIConfigStack.CASC_RELOAD_TOKEN_SECRET_EXPORT_VALUE}`);
     const listenerCertificate = ListenerCertificate.fromArn(certificateArn.secretValue.toString());
     const agentNode = new AgentNodes();
-    const agentNodes: AgentNodeProps[] = [agentNode.AL2_X64, agentNode.AL2_X64_DOCKER_HOST, agentNode.AL2_ARM64, agentNode.AL2_ARM64_DOCKER_HOST,
-      agentNode.UBUNTU_X64, agentNode.UBUNTU_X64_DOCKER_BUILDER];
+    const agentNodes: AgentNodeProps[] = [agentNode.AL2_X64, agentNode.AL2_X64_DOCKER_HOST, agentNode.AL2_X64_DOCKER_HOST_PERF_TEST,
+      agentNode.AL2_ARM64, agentNode.AL2_ARM64_DOCKER_HOST, agentNode.UBUNTU_X64, agentNode.UBUNTU_X64_DOCKER_BUILDER];
 
     const mainJenkinsNode = new JenkinsMainNode(this, {
       vpc,

--- a/lib/compute/agent-nodes.ts
+++ b/lib/compute/agent-nodes.ts
@@ -17,6 +17,8 @@ export class AgentNodes {
 
     readonly AL2_X64_DOCKER_HOST: AgentNodeProps;
 
+    readonly AL2_X64_DOCKER_HOST_PERF_TEST: AgentNodeProps;
+
     readonly AL2_ARM64: AgentNodeProps;
 
     readonly AL2_ARM64_DOCKER_HOST: AgentNodeProps;
@@ -38,6 +40,15 @@ export class AgentNodes {
       this.AL2_X64_DOCKER_HOST = {
         workerLabelString: 'Jenkins-Agent-al2-x64-c54xlarge-Docker-Host',
         instanceType: 'C54xlarge',
+        remoteUser: 'ec2-user',
+        numExecutors: 8,
+        amiId: 'ami-00a07e55fcad01043',
+        initScript: 'sudo yum clean all && sudo rm -rf /var/cache/yum/* && sudo yum repolist &&'
+        + ' sudo yum update --skip-broken --exclude=openssh* --exclude=docker* -y',
+      };
+      this.AL2_X64_DOCKER_HOST_PERF_TEST = {
+        workerLabelString: 'Jenkins-Agent-al2-x64-m52xlarge-Docker-Host-Perf-Test',
+        instanceType: 'M52xlarge',
         remoteUser: 'ec2-user',
         numExecutors: 8,
         amiId: 'ami-00a07e55fcad01043',


### PR DESCRIPTION
Signed-off-by: Peter Zhu <zhujiaxi@amazon.com>

### Description
Migrate perf test agent setups to public jenkins

### Issues Resolved
Part of https://github.com/opensearch-project/opensearch-ci/issues/132

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
