### PR TITLE
Make jenkins jdk tool match manifest jdk naming

### DIFF
--- a/resources/baseJenkins.yaml
+++ b/resources/baseJenkins.yaml
@@ -159,25 +159,25 @@ tool:
       name: "Default"
   jdk:
     installations:
-    - name: "jdk-8"
+    - name: "openjdk-8"
       properties:
       - installSource:
           installers:
           - adoptOpenJdkInstaller:
               id: "jdk8u332-b09"
-    - name: "jdk-11"
+    - name: "openjdk-11"
       properties:
       - installSource:
           installers:
           - adoptOpenJdkInstaller:
               id: "jdk-11.0.15+10"
-    - name: "jdk-14"
+    - name: "openjdk-14"
       properties:
       - installSource:
           installers:
           - adoptOpenJdkInstaller:
               id: "jdk-14.0.2+12"
-    - name: "jdk-17"
+    - name: "openjdk-17"
       properties:
       - installSource:
           installers:

--- a/test/data/test_env.yaml
+++ b/test/data/test_env.yaml
@@ -171,25 +171,25 @@ tool:
         name: Default
   jdk:
     installations:
-      - name: jdk-8
+      - name: openjdk-8
         properties:
           - installSource:
               installers:
                 - adoptOpenJdkInstaller:
                     id: jdk8u332-b09
-      - name: jdk-11
+      - name: openjdk-11
         properties:
           - installSource:
               installers:
                 - adoptOpenJdkInstaller:
                     id: jdk-11.0.15+10
-      - name: jdk-14
+      - name: openjdk-14
         properties:
           - installSource:
               installers:
                 - adoptOpenJdkInstaller:
                     id: jdk-14.0.2+12
-      - name: jdk-17
+      - name: openjdk-17
         properties:
           - installSource:
               installers:


### PR DESCRIPTION
Signed-off-by: Peter Zhu <zhujiaxi@amazon.com>

### Description
Make jenkins jdk tool match manifest jdk naming

### Issues Resolved
Part of #2362, https://github.com/opensearch-project/opensearch-build/pull/2365

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
