### PR TITLE
Fix gradle check by removing old caches and add back docker-compose

### DIFF
--- a/lib/compute/agent-nodes.ts
+++ b/lib/compute/agent-nodes.ts
@@ -99,7 +99,7 @@ export class AgentNodes {
         amiId: 'ami-0f6ceb3b3687a3fba',
         initScript: 'sudo apt-mark hold docker docker.io openssh-server && docker ps &&'
         + ' sudo apt-get update && (sudo killall -9 apt-get apt 2>&1 || echo) &&'
-        + ' sudo apt-get upgrade -y && sudo apt-get install -y ntp &&'
+        + ' sudo apt-get upgrade -y && sudo apt-get install -y ntp docker-compose &&'
         + ' sudo systemctl restart ntp && sudo systemctl enable ntp',
       };
       this.UBUNTU2004_X64_DOCKER_BUILDER = {
@@ -112,7 +112,7 @@ export class AgentNodes {
         amiId: 'ami-0f6ceb3b3687a3fba',
         initScript: 'sudo apt-mark hold docker docker.io openssh-server && docker ps &&'
         + ' sudo apt-get update && (sudo killall -9 apt-get apt 2>&1 || echo) &&'
-        + ' sudo apt-get upgrade -y && sudo apt-get install -y ntp &&'
+        + ' sudo apt-get upgrade -y && sudo apt-get install -y ntp docker-compose &&'
         + ' sudo systemctl restart ntp && sudo systemctl enable ntp',
       };
       this.MACOS12_X64_MULTI_HOST = {

--- a/lib/compute/jenkins-main-node.ts
+++ b/lib/compute/jenkins-main-node.ts
@@ -365,7 +365,7 @@ export class JenkinsMainNode {
       InitCommand.shellCommand('/opt/aws/amazon-cloudwatch-agent/bin/amazon-cloudwatch-agent-ctl -a fetch-config -m ec2 -c file:/opt/aws/amazon-cloudwatch-agent/etc/amazon-cloudwatch-agent.json -s'),
 
       InitCommand.shellCommand(dataRetentionProps.dataRetention
-        ? `mkdir /var/lib/jenkins && mount -t efs ${efsId} /var/lib/jenkins && rm -rf /var/lib/jenkins/caches/*`
+        ? `mkdir /var/lib/jenkins && mount -t efs ${efsId} /var/lib/jenkins && rm -vrf /var/lib/jenkins/caches/adoptopenjdk/*`
         : 'echo Data rentention is disabled, not mounting efs'),
 
       InitFile.fromFileInline('/docker-compose.yml', join(__dirname, '../../resources/docker-compose.yml')),

--- a/lib/compute/jenkins-main-node.ts
+++ b/lib/compute/jenkins-main-node.ts
@@ -365,7 +365,7 @@ export class JenkinsMainNode {
       InitCommand.shellCommand('/opt/aws/amazon-cloudwatch-agent/bin/amazon-cloudwatch-agent-ctl -a fetch-config -m ec2 -c file:/opt/aws/amazon-cloudwatch-agent/etc/amazon-cloudwatch-agent.json -s'),
 
       InitCommand.shellCommand(dataRetentionProps.dataRetention
-        ? `mkdir /var/lib/jenkins && mount -t efs ${efsId} /var/lib/jenkins`
+        ? `mkdir /var/lib/jenkins && mount -t efs ${efsId} /var/lib/jenkins && rm -rf /var/lib/jenkins/caches/*`
         : 'echo Data rentention is disabled, not mounting efs'),
 
       InitFile.fromFileInline('/docker-compose.yml', join(__dirname, '../../resources/docker-compose.yml')),

--- a/lib/compute/jenkins-main-node.ts
+++ b/lib/compute/jenkins-main-node.ts
@@ -365,7 +365,7 @@ export class JenkinsMainNode {
       InitCommand.shellCommand('/opt/aws/amazon-cloudwatch-agent/bin/amazon-cloudwatch-agent-ctl -a fetch-config -m ec2 -c file:/opt/aws/amazon-cloudwatch-agent/etc/amazon-cloudwatch-agent.json -s'),
 
       InitCommand.shellCommand(dataRetentionProps.dataRetention
-        ? `mkdir /var/lib/jenkins && mount -t efs ${efsId} /var/lib/jenkins && rm -vrf /var/lib/jenkins/caches/adoptopenjdk/*`
+        ? `mkdir /var/lib/jenkins && mount -t efs ${efsId} /var/lib/jenkins`
         : 'echo Data rentention is disabled, not mounting efs'),
 
       InitFile.fromFileInline('/docker-compose.yml', join(__dirname, '../../resources/docker-compose.yml')),


### PR DESCRIPTION
Signed-off-by: Peter Zhu <zhujiaxi@amazon.com>

### Description
1. 
In this PR: https://github.com/opensearch-project/opensearch-ci/commit/c2f5e810a61778382d83382346806c6a88243494, docker-compose was mistakenly removed thus failed the run:
https://build.ci.opensearch.org/job/gradle-check/1024/console

This PR fix both of these issues.

### Issues Resolved
_List any issues this PR will resolve, e.g. Closes [...]._ 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
