### PR TITLE
Changed cpu and memory metric stat to avg

### DIFF
--- a/lib/compute/jenkins-main-node.ts
+++ b/lib/compute/jenkins-main-node.ts
@@ -337,7 +337,7 @@ export class JenkinsMainNode {
           metrics_collected: {
             procstat: [
               {
-                pattern: 'jenkins',
+                pattern: 'Djenkins',
                 measurement: [
                   'cpu_usage',
                   'cpu_time_system',

--- a/lib/monitoring/ci-alarms.ts
+++ b/lib/monitoring/ci-alarms.ts
@@ -39,7 +39,7 @@ export class JenkinsMonitoring {
 
     this.alarms.push(new Alarm(stack, 'MainNodeHighCpuUtilization', {
       alarmDescription: 'The jenkins process is using much more CPU that expected, it should be investigated for a stuck process/job',
-      metric: mainNode.ec2InstanceMetrics.cpuTime.with({ statistic: 'max' }),
+      metric: mainNode.ec2InstanceMetrics.cpuTime.with({ statistic: 'avg' }),
       evaluationPeriods: 5,
       threshold: 50,
       comparisonOperator: ComparisonOperator.GREATER_THAN_OR_EQUAL_TO_THRESHOLD,
@@ -48,7 +48,7 @@ export class JenkinsMonitoring {
 
     this.alarms.push(new Alarm(stack, 'MainNodeHighMemoryUtilization', {
       alarmDescription: 'The jenkins process is using more memory than expected, it should be investigated for a large number of jobs or heavy weight jobs',
-      metric: mainNode.ec2InstanceMetrics.memUsed.with({ statistic: 'max' }),
+      metric: mainNode.ec2InstanceMetrics.memUsed.with({ statistic: 'avg' }),
       evaluationPeriods: 5,
       threshold: 50,
       comparisonOperator: ComparisonOperator.GREATER_THAN_OR_EQUAL_TO_THRESHOLD,

--- a/test/ci-stack.test.ts
+++ b/test/ci-stack.test.ts
@@ -35,6 +35,7 @@ test('CI Stack Basic Resources', () => {
   expect(stack).to(countResources('AWS::SSM::Document', 1));
   expect(stack).to(countResources('AWS::SSM::Association', 1));
   expect(stack).to(countResources('AWS::EFS::FileSystem', 1));
+  expect(stack).to(countResources('AWS::CloudWatch::Alarm', 5));
 });
 
 test('External security group is open', () => {
@@ -139,5 +140,35 @@ test('LoadBalancer', () => {
         ],
       },
     ],
+  }, ResourcePart.Properties));
+});
+
+test('CloudwatchCpuAlarm', () => {
+  const app = new App({
+    context: { useSsl: 'false', runWithOidc: 'false' },
+  });
+
+  // WHEN
+  const stack = new CIStack(app, 'MyTestStack', {});
+
+  // THEN
+  expect(stack).to(haveResourceLike('AWS::CloudWatch::Alarm', {
+    MetricName: 'procstat_cpu_usage',
+    Statistic: 'Average',
+  }, ResourcePart.Properties));
+});
+
+test('CloudwatchMemoryAlarm', () => {
+  const app = new App({
+    context: { useSsl: 'false', runWithOidc: 'false' },
+  });
+
+  // WHEN
+  const stack = new CIStack(app, 'MyTestStack', {});
+
+  // THEN
+  expect(stack).to(haveResourceLike('AWS::CloudWatch::Alarm', {
+    MetricName: 'mem_used_percent',
+    Statistic: 'Average',
   }, ResourcePart.Properties));
 });


### PR DESCRIPTION
Signed-off-by: Rishabh Singh <sngri@amazon.com>

### Description
This PR is to update the metric stat from `max` to `avg` for jenkins process cpu and memory utilization. 
Also updated the `procstat` metric patter to `Djenkins` as there are to process running on the instance that contain the keyword `jenkins`. 

```
[root@ip-10-0-138-75 ~]# ps aux|grep -v grep|grep jenkins
root      5873  0.0  0.0   1152     4 pts/0    Ss   13:24   0:00 /sbin/tini -- /usr/local/bin/jenkins.sh
root      5953  4.9 10.2 17853440 3307496 pts/0 Sl+ 13:24   1:21 java -Duser.home=/var/jenkins_home -Djenkins.install.runSetupWizard=false -Xmx8g -Djenkins.model.Jenkins.slaveAgentPort=50000 -Dhudson.lifecycle=hudson.lifecycle.ExitLifecycle -jar /usr/share/jenkins/jenkins.war
``` 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
