### PR TITLE
Add ability to assume multiple roles

### DIFF
--- a/lib/compute/agent-node-config.ts
+++ b/lib/compute/agent-node-config.ts
@@ -42,7 +42,7 @@ export class AgentNodeConfig {
 
    public readonly SSHEC2KeySecretId: string;
 
-   constructor(stack: Stack, assumeRole: string) {
+   constructor(stack: Stack, assumeRole?: string[]) {
      this.STACKREGION = stack.region;
      this.ACCOUNT = stack.account;
 
@@ -61,7 +61,6 @@ export class AgentNodeConfig {
 
      const ecrManagedPolicy = new ManagedPolicy(stack, 'OpenSearch-CI-AgentNodePolicy', {
        description: 'Jenkins agents Node Policy',
-       managedPolicyName: 'OpenSearch-CI-AgentNodePolicy',
        statements: [
          new PolicyStatement({
            effect: Effect.ALLOW,
@@ -107,11 +106,11 @@ export class AgentNodeConfig {
      );
 
      /* eslint-disable eqeqeq */
-     if (assumeRole.toString() !== 'undefined') {
+     if (assumeRole) {
        // policy to allow assume role AssumeRole
        AgentNodeRole.addToPolicy(
          new PolicyStatement({
-           resources: [assumeRole],
+           resources: assumeRole,
            actions: ['sts:AssumeRole'],
          }),
        );

--- a/lib/compute/jenkins-main-node.ts
+++ b/lib/compute/jenkins-main-node.ts
@@ -91,7 +91,7 @@ export class JenkinsMainNode {
     foundJenkinsProcessCount: Metric
   }
 
-  constructor(stack: Stack, props: JenkinsMainNodeProps, agentNode: AgentNodeProps[], assumeRole: string, macAgent: string) {
+  constructor(stack: Stack, props: JenkinsMainNodeProps, agentNode: AgentNodeProps[], macAgent: string, assumeRole?: string[]) {
     this.ec2InstanceMetrics = {
       cpuTime: new Metric({
         metricName: 'procstat_cpu_usage',

--- a/test/compute/agent-node-config.test.ts
+++ b/test/compute/agent-node-config.test.ts
@@ -8,12 +8,11 @@
 
 import { Stack, App } from '@aws-cdk/core';
 import {
-  expect as expectCDK, haveResource, haveResourceLike, countResources,
+  expect as expectCDK, haveResourceLike,
 } from '@aws-cdk/assert';
 import { readFileSync } from 'fs';
 import { load } from 'js-yaml';
 import { CIStack } from '../../lib/ci-stack';
-import { JenkinsMainNode } from '../../lib/compute/jenkins-main-node';
 
 test('Agents Resource is present', () => {
   const app = new App({
@@ -49,7 +48,6 @@ test('Agents Resource is present', () => {
   expectCDK(stack).to(haveResourceLike('AWS::IAM::ManagedPolicy', {
     Description: 'Jenkins agents Node Policy',
     Path: '/',
-    ManagedPolicyName: 'OpenSearch-CI-AgentNodePolicy',
     Roles: [
       {
         Ref: 'OpenSearchCIAgentNodeRole4270FE0F',
@@ -121,6 +119,32 @@ test('Agents Resource is present', () => {
       ],
       Version: '2012-10-17',
     },
+  }));
+});
+
+test('Agents Node policy with assume role Resource is present', () => {
+  const app = new App({
+    context: { useSsl: 'true', runWithOidc: 'true' },
+  });
+  const stack = new CIStack(app, 'TestStack', {
+    agentAssumeRole: ['arn:aws:iam::12345:role/test-role', 'arn:aws:iam::901523:role/test-role2'],
+  });
+
+  expectCDK(stack).to(haveResourceLike('AWS::IAM::Policy', {
+    PolicyDocument: {
+      Statement: [
+        {
+          Action: 'sts:AssumeRole',
+          Effect: 'Allow',
+          Resource: [
+            'arn:aws:iam::12345:role/test-role',
+            'arn:aws:iam::901523:role/test-role2',
+          ],
+        },
+      ],
+      Version: '2012-10-17',
+    },
+
   }));
 });
 


### PR DESCRIPTION
Signed-off-by: Sayali Gaikawad <gaiksaya@amazon.com>

### Description
A single agent node role might need to assume multiple roles across different accounts. This PR adds that functionality.
Also removes policy name that causes conflict during multiple deployments.

### Issues Resolved
_List any issues this PR will resolve, e.g. Closes [...]._ 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
