### PR TITLE
added alarm on avg cpu utilization of ec2 instance

### DIFF
--- a/lib/compute/jenkins-main-node.ts
+++ b/lib/compute/jenkins-main-node.ts
@@ -86,17 +86,12 @@ export class JenkinsMainNode {
   public readonly ec2Instance: Instance;
 
   public readonly ec2InstanceMetrics: {
-    cpuTime: Metric,
     memUsed: Metric,
     foundJenkinsProcessCount: Metric
   }
 
   constructor(stack: Stack, props: JenkinsMainNodeProps, agentNode: AgentNodeProps[], macAgent: string, assumeRole?: string[]) {
     this.ec2InstanceMetrics = {
-      cpuTime: new Metric({
-        metricName: 'procstat_cpu_usage',
-        namespace: `${stack.stackName}/JenkinsMainNode`,
-      }),
       memUsed: new Metric({
         metricName: 'mem_used_percent',
         namespace: `${stack.stackName}/JenkinsMainNode`,

--- a/test/ci-stack.test.ts
+++ b/test/ci-stack.test.ts
@@ -153,7 +153,7 @@ test('CloudwatchCpuAlarm', () => {
 
   // THEN
   expect(stack).to(haveResourceLike('AWS::CloudWatch::Alarm', {
-    MetricName: 'procstat_cpu_usage',
+    MetricName: 'CPUUtilization',
     Statistic: 'Average',
   }, ResourcePart.Properties));
 });


### PR DESCRIPTION
Signed-off-by: Rishabh Singh <sngri@amazon.com>

### Description
This PR adds CW Alarm on overall average cpu utilization of jenkins main node instance. 

### Issues Resolved


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
