### PR TITLE
Fix gh upgrade changing pgp keys

### DIFF
--- a/lib/compute/agent-nodes.ts
+++ b/lib/compute/agent-nodes.ts
@@ -45,7 +45,7 @@ export class AgentNodes {
       numExecutors: 1,
       amiId: 'ami-02741203de07205f3',
       initScript: 'sudo yum clean all && sudo rm -rf /var/cache/yum /var/lib/yum/history && sudo yum repolist &&'
-      + ' sudo yum update --skip-broken --exclude=openssh* --exclude=docker* -y && docker ps',
+      + ' sudo yum update --skip-broken --exclude=openssh* --exclude=docker* --exclude=gh* -y && docker ps',
       remoteFs: '/var/jenkins',
     };
     this.AL2_X64_DOCKER_HOST = {
@@ -58,7 +58,7 @@ export class AgentNodes {
       numExecutors: 4,
       amiId: 'ami-02741203de07205f3',
       initScript: 'sudo yum clean all && sudo rm -rf /var/cache/yum /var/lib/yum/history && sudo yum repolist &&'
-      + ' sudo yum update --skip-broken --exclude=openssh* --exclude=docker* -y && docker ps',
+      + ' sudo yum update --skip-broken --exclude=openssh* --exclude=docker* --exclude=gh* -y && docker ps',
       remoteFs: '/var/jenkins',
     };
     this.AL2_X64_DOCKER_HOST_PERF_TEST = {
@@ -71,7 +71,7 @@ export class AgentNodes {
       numExecutors: 8,
       amiId: 'ami-02741203de07205f3',
       initScript: 'sudo yum clean all && sudo rm -rf /var/cache/yum /var/lib/yum/history && sudo yum repolist &&'
-      + ' sudo yum update --skip-broken --exclude=openssh* --exclude=docker* -y && docker ps',
+      + ' sudo yum update --skip-broken --exclude=openssh* --exclude=docker* --exclude=gh* -y && docker ps',
       remoteFs: '/var/jenkins',
     };
     this.AL2_ARM64 = {
@@ -84,7 +84,7 @@ export class AgentNodes {
       numExecutors: 1,
       amiId: 'ami-036fed467cf2ed593',
       initScript: 'sudo yum clean all && sudo rm -rf /var/cache/yum /var/lib/yum/history && sudo yum repolist &&'
-      + ' sudo yum update --skip-broken --exclude=openssh* --exclude=docker* -y && docker ps',
+      + ' sudo yum update --skip-broken --exclude=openssh* --exclude=docker* --exclude=gh* -y && docker ps',
       remoteFs: '/var/jenkins',
     };
     this.AL2_ARM64_DOCKER_HOST = {
@@ -97,7 +97,7 @@ export class AgentNodes {
       numExecutors: 4,
       amiId: 'ami-036fed467cf2ed593',
       initScript: 'sudo yum clean all && sudo rm -rf /var/cache/yum /var/lib/yum/history && sudo yum repolist &&'
-      + ' sudo yum update --skip-broken --exclude=openssh* --exclude=docker* -y && docker ps',
+      + ' sudo yum update --skip-broken --exclude=openssh* --exclude=docker* --exclude=gh* -y && docker ps',
       remoteFs: '/var/jenkins',
     };
     this.UBUNTU2004_X64 = {
@@ -109,7 +109,7 @@ export class AgentNodes {
       minimumNumberOfSpareInstances: 1,
       numExecutors: 1,
       amiId: 'ami-0908180d5832dbd2b',
-      initScript: 'sudo apt-mark hold docker docker.io openssh-server && docker ps &&'
+      initScript: 'sudo apt-mark hold docker docker.io openssh-server gh && docker ps &&'
       + ' sudo apt-get update -y && (sudo killall -9 apt-get apt 2>&1 || echo) && sudo apt-get upgrade -y',
       remoteFs: '/var/jenkins',
     };
@@ -122,7 +122,7 @@ export class AgentNodes {
       minimumNumberOfSpareInstances: 1,
       numExecutors: 1,
       amiId: 'ami-0908180d5832dbd2b',
-      initScript: 'sudo apt-mark hold docker docker.io openssh-server && docker ps &&'
+      initScript: 'sudo apt-mark hold docker docker.io openssh-server gh && docker ps &&'
       + ' sudo apt-get update -y && (sudo killall -9 apt-get apt 2>&1 || echo) && sudo apt-get upgrade -y',
       remoteFs: '/var/jenkins',
     };


### PR DESCRIPTION
Signed-off-by: Peter Zhu <zhujiaxi@amazon.com>

### Description
Fix gh upgrade changing pgp keys

### Issues Resolved
```
(3/3): gh_2.15.0_linux_arm64.rpm                           | 7.0 MB   00:00     
--------------------------------------------------------------------------------
Total                                               65 MB/s | 7.6 MB  00:00     
Retrieving key from https://keyserver.ubuntu.com/pks/lookup?op=get&search=0xc99b11deb97541f0


The GPG keys listed for the "packages for the GitHub CLI" repository are already installed but they are not correct for this package.
Check that the correct key URLs are configured for this repository.


 Failing package is: gh-2.15.0-1.aarch64
 GPG Keys are configured as: https://keyserver.ubuntu.com/pks/lookup?op=get&search=0xc99b11deb97541f0

Sep 06, 2022 6:33:19 PM hudson.plugins.ec2.EC2Cloud
WARNING: init script failed: exit code=1


```

Related to this: https://github.com/cli/cli/issues/6175
We will update the packer at a later time but for now we will block the upgrade as it is not needed to be upgraded now.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
