### PR TITLE
Update JDK14 to use zip installer as Jenkins has stopped support

### DIFF
--- a/resources/baseJenkins.yaml
+++ b/resources/baseJenkins.yaml
@@ -175,8 +175,8 @@ tool:
       properties:
       - installSource:
           installers:
-          - adoptOpenJdkInstaller:
-              id: "jdk-14.0.2+12"
+          - zip:
+              url: "https://ci.opensearch.org/ci/dbc/tools/OpenJDK14U-jdk_x64_linux_hotspot_14.0.2_12.zip"
     - name: "openjdk-17"
       properties:
       - installSource:

--- a/test/data/test_env.yaml
+++ b/test/data/test_env.yaml
@@ -187,8 +187,9 @@ tool:
         properties:
           - installSource:
               installers:
-                - adoptOpenJdkInstaller:
-                    id: jdk-14.0.2+12
+                - zip:
+                    url: >-
+                      https://ci.opensearch.org/ci/dbc/tools/OpenJDK14U-jdk_x64_linux_hotspot_14.0.2_12.zip
       - name: openjdk-17
         properties:
           - installSource:


### PR DESCRIPTION
Signed-off-by: Peter Zhu <zhujiaxi@amazon.com>

### Description
Update JDK14 to use zip installer as Jenkins has stopped support

### Issues Resolved
https://github.com/opensearch-project/opensearch-build/issues/2604

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
