### PR TITLE
Restore maxrun of windows agent to unlimited

### DIFF
--- a/lib/compute/agent-nodes.ts
+++ b/lib/compute/agent-nodes.ts
@@ -143,7 +143,7 @@ export class AgentNodes {
       workerLabelString: 'Jenkins-Agent-Windows2019-X64-C54xlarge-Single-Host',
       instanceType: 'C54xlarge',
       remoteUser: 'Administrator',
-      maxTotalUses: 10,
+      maxTotalUses: -1,
       minimumNumberOfSpareInstances: 2,
       numExecutors: 1,
       amiId: 'ami-0eb10b1babd0c157d',


### PR DESCRIPTION
Signed-off-by: Peter Zhu <zhujiaxi@amazon.com>

### Description
Restore maxrun of windows agent to unlimited

### Issues Resolved
https://github.com/opensearch-project/opensearch-build/issues/2306

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
