### PR TITLE
Replace nvm with volta for Windows Agent

### DIFF
--- a/packer/scripts/windows/scoop-install-commons.ps1
+++ b/packer/scripts/windows/scoop-install-commons.ps1
@@ -87,14 +87,16 @@ Rename-Item "$pythonLibHome\\site-packages_temp" "$pythonLibHome\\site-packages"
 scoop install maven
 mvn --version
 
-# Install nvm (the last in order is default as nvm-win does not allow nvm alias/use default <version>)
-scoop install nvm
-nvm install 10.24.1
-nvm use 10.24.1
-npm install -g yarn
-nvm install 14.19.1
-nvm use 14.19.1
-npm install -g yarn
+# Install volta to replace nvm on Windows as Windows is not able to handle symlink after AMI creation
+# While Volta is using a fixed location and switch version dynamically for the Windows Agent
+scoop install volta
+$nodeVersionList = "10.24.1","14.19.1","14.20.0"
+Foreach ($nodeVersion in $nodeVersionList)
+{
+    $nodeVersion
+    volta install "node@$nodeVersion"
+    npm install -g yarn
+}
 
 # Install ruby24
 scoop install ruby24

--- a/packer/scripts/windows/scoop-install-commons.ps1
+++ b/packer/scripts/windows/scoop-install-commons.ps1
@@ -88,7 +88,7 @@ scoop install maven
 mvn --version
 
 # Install volta to replace nvm on Windows as Windows is not able to handle symlink after AMI creation
-# While Volta is using a fixed location and switch version dynamically for the Windows Agent
+# While Volta is using a fixed location and switch binary version automatically for the Windows Agent
 scoop install volta
 volta --version
 $nodeVersionList = "10.24.1","14.19.1","14.20.0"


### PR DESCRIPTION
### Description
Replace nvm with volta for Windows Agent.
Volta has fixed path regardless of which nodejs version it is switching to, therefore more suitable for windows env as we can simply define the path through env vars. NVM use symlink to switch version which does not preserve during the windows ami creation.

### Issues Resolved
https://github.com/opensearch-project/opensearch-build/issues/2306

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
