### PR TITLE
Restore windows to use 1 executor max

### DIFF
--- a/lib/compute/agent-nodes.ts
+++ b/lib/compute/agent-nodes.ts
@@ -147,7 +147,7 @@ export class AgentNodes {
       remoteUser: 'Administrator',
       maxTotalUses: -1,
       minimumNumberOfSpareInstances: 2,
-      numExecutors: 2,
+      numExecutors: 1,
       amiId: 'ami-006c911a4bd898d4a',
       initScript: 'echo',
       remoteFs: 'C:\\Users\\Administrator\\jenkins',


### PR DESCRIPTION
Signed-off-by: Peter Zhu <zhujiaxi@amazon.com>

### Description
Restore windows to use 1 executor max

Recent checks shows that if there are two or more executors get a hook on bash.exe, while trying to deploy to mavenlocal, which is `C:\\Users\\Administrator\\.m2` the second process will not be able to access. The folder has to be forcefully removed before a second process can take over. Seems like some types of protection lock on Windows, since we are not having docker windows on windows.

```
FAILURE: Build failed with an exception.

* What went wrong:
Execution failed for task ':client:test:publishNebulaPublicationToMavenLocal'.
> Failed to publish publication 'nebula' to repository 'mavenLocal'
   > Could not write to resource 'file:/C:/Users/Administrator/.m2/repository/org/opensearch/client/test/test/2.4.0/test-2.4.0.jar'.
      > Unable to create parent directories of C:\Users\Administrator\.m2\repository\org\opensearch\client\test\test\2.4.0\test-2.4.0.jar


```

### Issues Resolved
https://github.com/opensearch-project/opensearch-build/issues/2306

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
