### PR TITLE
Resolve incorrectly added env vars for Windows

### DIFF
--- a/lib/compute/agent-nodes.ts
+++ b/lib/compute/agent-nodes.ts
@@ -148,7 +148,7 @@ export class AgentNodes {
       maxTotalUses: -1,
       minimumNumberOfSpareInstances: 2,
       numExecutors: 1,
-      amiId: 'ami-04e3e1e593eb9b709',
+      amiId: 'ami-0720b70e6cb2e8012',
       initScript: 'echo',
       remoteFs: 'C:\\Users\\Administrator\\jenkins',
     };
@@ -160,7 +160,7 @@ export class AgentNodes {
       maxTotalUses: 1,
       minimumNumberOfSpareInstances: 1,
       numExecutors: 1,
-      amiId: 'ami-04e3e1e593eb9b709',
+      amiId: 'ami-0720b70e6cb2e8012',
       initScript: 'echo',
       remoteFs: 'C:\\Users\\Administrator\\jenkins',
     };

--- a/packer/scripts/windows/scoop-install-commons.ps1
+++ b/packer/scripts/windows/scoop-install-commons.ps1
@@ -19,8 +19,8 @@ $fileFound
 $gitPathFound = $fileFound.replace("$fileName", '')
 $gitPathFound
 # Add to EnvVar
-$userenv = [System.Environment]::GetEnvironmentVariable("Path", "User")
-[System.Environment]::SetEnvironmentVariable("PATH", $userenv + ";$gitPathFound", "User")
+$userenv = [System.Environment]::GetEnvironmentVariable("Path", [System.EnvironmentVariableTarget]::User)
+[System.Environment]::SetEnvironmentVariable("PATH", $userenv + ";$gitPathFound", [System.EnvironmentVariableTarget]::User)
 # Make sure mem size are set to avoid "Out of memory, malloc failed" issues on Windows
 git config --system core.packedGitLimit 128m
 git config --system core.packedGitWindowSize 128m
@@ -57,7 +57,7 @@ $libPathFound = $libFound.replace("$libName", '')
 $libPathFound
 mv -v "$libFound" "$libPathFound\\$libNameRequired"
 # Add MINGW_BIN path to User Env Var for k-NN to retrieve libs
-[System.Environment]::SetEnvironmentVariable("MINGW_BIN", "$libPathFound", "User")
+[System.Environment]::SetEnvironmentVariable("MINGW_BIN", "$libPathFound", [System.EnvironmentVariableTarget]::User)
 
 # Install zlib for k-NN compilation requirements
 scoop install zlib
@@ -114,9 +114,9 @@ Foreach ($nodeVersion in $nodeVersionList)
 }
 volta install yarn
 yarn --version
-$userenv2 = [System.Environment]::GetEnvironmentVariable("Path", "User")
+$userenv2 = [System.Environment]::GetEnvironmentVariable("Path", [System.EnvironmentVariableTarget]::User)
 $nodePathFixed = "C:\\Users\\Administrator\\scoop\\persist\\volta\\appdata\\bin"
-[System.Environment]::SetEnvironmentVariable("PATH", $userenv2 + ";$nodePathFixed", "User")
+[System.Environment]::SetEnvironmentVariable("PATH", $userenv2 + ";$nodePathFixed", [System.EnvironmentVariableTarget]::User)
 
 # Install ruby24
 scoop install ruby24


### PR DESCRIPTION
Signed-off-by: Peter Zhu <zhujiaxi@amazon.com>

### Description
Resolve incorrectly added env vars for Windows

### Issues Resolved
https://github.com/opensearch-project/opensearch-build/issues/2306

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
