### PR TITLE
Add JENKINS_HOME_PATH as default JENKINS_HOME always returns /var/jenkins_home

### DIFF
--- a/lib/compute/agent-node-config.ts
+++ b/lib/compute/agent-node-config.ts
@@ -196,6 +196,18 @@ export class AgentNodeConfig {
       ],
       tenancy: 'Default',
       type: config.instanceType,
+      nodeProperties: [
+        {
+          envVars: {
+            env: [
+              {
+                key: 'JENKINS_HOME_PATH',
+                value: config.remoteFs,
+              },
+            ],
+          },
+        },
+      ],
       useEphemeralDevices: false,
     };
   }
@@ -243,6 +255,18 @@ export class AgentNodeConfig {
       ],
       tenancy: 'Host',
       type: config.instanceType,
+      nodeProperties: [
+        {
+          envVars: {
+            env: [
+              {
+                key: 'JENKINS_HOME_PATH',
+                value: config.remoteFs,
+              },
+            ],
+          },
+        },
+      ],
       useEphemeralDevices: false,
     };
   }
@@ -293,6 +317,18 @@ export class AgentNodeConfig {
       ],
       tenancy: 'Default',
       type: config.instanceType,
+      nodeProperties: [
+        {
+          envVars: {
+            env: [
+              {
+                key: 'JENKINS_HOME_PATH',
+                value: config.remoteFs,
+              },
+            ],
+          },
+        },
+      ],
       useEphemeralDevices: false,
     };
   }

--- a/resources/baseJenkins.yaml
+++ b/resources/baseJenkins.yaml
@@ -175,8 +175,16 @@ tool:
       properties:
       - installSource:
           installers:
-          - zip:
-              url: "https://ci.opensearch.org/ci/dbc/tools/OpenJDK14U-jdk_x64_linux_hotspot_14.0.2_12.zip"
+          - command:
+              command: "JENKINS_HOME_LINUX=\"/var/jenkins\"\nJENKINS_HOME_WINDOWS=\"\
+                C:/Users/Administrator/jenkins\"\n \n\nif uname -s | grep -i NT; then\n\
+                \    echo windows agent\n    JENKINS_JDK14_PATH=$JENKINS_HOME_WINDOWS/tools/hudson.model.JDK/openjdk-14\n\
+                \    JDK14_ZIP=\"OpenJDK14U-jdk_x64_windows_hotspot_14.0.2_12.zip\"\
+                \n    \nelse\n     echo linux agent\n     JENKINS_JDK14_PATH=$JENKINS_HOME_LINUX/tools/hudson.model.JDK/openjdk-14\n\
+                \     JDK14_ZIP=\"OpenJDK14U-jdk_x64_linux_hotspot_14.0.2_12.zip\"\
+                \n     \nfi\n\n\nmkdir -p $JENKINS_JDK14_PATH\ncd $JENKINS_JDK14_PATH\n\
+                pwd\nrm -rf ./*\ncurl -sSL https://ci.opensearch.org/ci/dbc/tools/$JDK14_ZIP\
+                \ -o jdk14.zip\nunzip -q jdk14.zip\nrm jdk14.zip\n\n"
     - name: "openjdk-17"
       properties:
       - installSource:

--- a/test/data/test_env.yaml
+++ b/test/data/test_env.yaml
@@ -187,9 +187,43 @@ tool:
         properties:
           - installSource:
               installers:
-                - zip:
-                    url: >-
-                      https://ci.opensearch.org/ci/dbc/tools/OpenJDK14U-jdk_x64_linux_hotspot_14.0.2_12.zip
+                - command:
+                    command: >+
+                      JENKINS_HOME_LINUX="/var/jenkins"
+
+                      JENKINS_HOME_WINDOWS="C:/Users/Administrator/jenkins"
+                       
+
+                      if uname -s | grep -i NT; then
+                          echo windows agent
+                          JENKINS_JDK14_PATH=$JENKINS_HOME_WINDOWS/tools/hudson.model.JDK/openjdk-14
+                          JDK14_ZIP="OpenJDK14U-jdk_x64_windows_hotspot_14.0.2_12.zip"
+                          
+                      else
+                           echo linux agent
+                           JENKINS_JDK14_PATH=$JENKINS_HOME_LINUX/tools/hudson.model.JDK/openjdk-14
+                           JDK14_ZIP="OpenJDK14U-jdk_x64_linux_hotspot_14.0.2_12.zip"
+                           
+                      fi
+
+
+
+                      mkdir -p $JENKINS_JDK14_PATH
+
+                      cd $JENKINS_JDK14_PATH
+
+                      pwd
+
+                      rm -rf ./*
+
+                      curl -sSL
+                      https://ci.opensearch.org/ci/dbc/tools/$JDK14_ZIP -o
+                      jdk14.zip
+
+                      unzip -q jdk14.zip
+
+                      rm jdk14.zip
+
       - name: openjdk-17
         properties:
           - installSource:


### PR DESCRIPTION

Signed-off-by: Peter Zhu <zhujiaxi@amazon.com>

### Description
Add JENKINS_HOME_PATH as default JENKINS_HOME always returns /var/jenkins_home.
This is a backend settings required to support windows gradle check.
Due to LINUX and Windows having different home directory for Jenkins, we need a variable to export the value.
The issue is, the default JENKINS_HOME variable is always returning `/var/jenkins_home` regardless of the platform.

By adding a node var for the agents it will dynamically display the root based on the platform remote fs.

Thanks.

### Issues Resolved
https://github.com/opensearch-project/opensearch-build/issues/2306

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
