### PR TITLE
Bug: Fix cloudwatch alarm `MainNodeTooManyJenkinsProcessesFound`

### DIFF
--- a/lib/compute/jenkins-main-node.ts
+++ b/lib/compute/jenkins-main-node.ts
@@ -321,7 +321,7 @@ export class JenkinsMainNode {
           metrics_collected: {
             procstat: [
               {
-                pattern: 'Djenkins',
+                pattern: 'jenkins.war',
                 measurement: [
                   'cpu_usage',
                   'cpu_time_system',

--- a/lib/monitoring/ci-alarms.ts
+++ b/lib/monitoring/ci-alarms.ts
@@ -44,12 +44,13 @@ export class JenkinsMonitoring {
       treatMissingData: TreatMissingData.BREACHING,
     }));
 
-    this.alarms.push(new Alarm(stack, 'MainNodeTooManyJenkinsProcessesFound', {
-      alarmDescription: 'Only one jenkins process should run at any given time on the main node, there might be a cloudwatch configuration issue',
-      metric: mainNode.ec2InstanceMetrics.foundJenkinsProcessCount.with({ statistic: 'max' }),
-      evaluationPeriods: 3,
+    this.alarms.push(new Alarm(stack, 'MainNodeJenkinsProcessNotFound', {
+      alarmDescription: 'Jenkins process is not running',
+      metric: mainNode.ec2InstanceMetrics.foundJenkinsProcessCount.with({ statistic: 'avg' }),
+      evaluationPeriods: 1,
       threshold: 1,
-      comparisonOperator: ComparisonOperator.GREATER_THAN_THRESHOLD,
+      datapointsToAlarm: 1,
+      comparisonOperator: ComparisonOperator.LESS_THAN_THRESHOLD,
       treatMissingData: TreatMissingData.IGNORE,
     }));
 


### PR DESCRIPTION
Signed-off-by: Prudhvi Godithi <pgodithi@amazon.com>

### Description
Fix cloudwatch alarm `MainNodeTooManyJenkinsProcessesFound` to `MainNodeJenkinsProcessNotFound`

### Issues Resolved
https://github.com/opensearch-project/opensearch-ci/issues/217

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
