### PR TITLE
Remove jdk14 live installation and relies on pre-installed AMIs while fix gradle check issues

### DIFF
--- a/lib/compute/agent-nodes.ts
+++ b/lib/compute/agent-nodes.ts
@@ -150,7 +150,7 @@ export class AgentNodes {
       numExecutors: 1,
       amiId: 'ami-0720b70e6cb2e8012',
       initScript: 'echo',
-      remoteFs: 'C:\\Users\\Administrator\\jenkins',
+      remoteFs: 'C:/Users/Administrator/jenkins',
     };
     this.WINDOWS2019_X64_GRADLE_CHECK = {
       agentType: 'windows',
@@ -162,7 +162,7 @@ export class AgentNodes {
       numExecutors: 1,
       amiId: 'ami-0720b70e6cb2e8012',
       initScript: 'echo',
-      remoteFs: 'C:\\Users\\Administrator\\jenkins',
+      remoteFs: 'C:/Users/Administrator/jenkins',
     };
     this.AL2_X64_DEFAULT_AGENT = {
       agentType: 'unix',

--- a/packer/jenkins-agent-al2-arm64.json
+++ b/packer/jenkins-agent-al2-arm64.json
@@ -35,7 +35,7 @@
         ],
         "most_recent":true
       },
-      "associate_public_ip_address":false,
+      "associate_public_ip_address":true,
       "ssh_username":  "ec2-user",
       "ssh_timeout": "3h",
       "tags": {

--- a/packer/jenkins-agent-al2-x64.json
+++ b/packer/jenkins-agent-al2-x64.json
@@ -35,7 +35,7 @@
         ],
         "most_recent":true
       },
-      "associate_public_ip_address":false,
+      "associate_public_ip_address":true,
       "ssh_username":  "ec2-user",
       "ssh_timeout": "3h",
       "tags": {

--- a/packer/jenkins-agent-macos12-x64.json
+++ b/packer/jenkins-agent-macos12-x64.json
@@ -41,7 +41,7 @@
         ],
         "most_recent":true
       },
-      "associate_public_ip_address":false,
+      "associate_public_ip_address":true,
       "ssh_username":  "ec2-user", 
       "ssh_timeout": "3h",
       "tenancy": "host",

--- a/packer/jenkins-agent-ubuntu2004-x64.json
+++ b/packer/jenkins-agent-ubuntu2004-x64.json
@@ -35,7 +35,7 @@
         ],
         "most_recent":true
       },
-      "associate_public_ip_address":false,
+      "associate_public_ip_address":true,
       "ssh_username":  "ubuntu",
       "ssh_timeout": "3h",
       "tags": {

--- a/packer/jenkins-agent-win2016-x64.json
+++ b/packer/jenkins-agent-win2016-x64.json
@@ -36,7 +36,7 @@
         "most_recent":true
       },
       "user_data_file":"scripts/windows/userdata.ps1",
-      "associate_public_ip_address":false,
+      "associate_public_ip_address":true,
       "communicator":"winrm",
       "winrm_username":"Administrator",
       "winrm_timeout":"40m",

--- a/packer/jenkins-agent-win2019-x64-alpine-wsl.json
+++ b/packer/jenkins-agent-win2019-x64-alpine-wsl.json
@@ -36,7 +36,7 @@
         "most_recent":true
       },
       "user_data_file":"scripts/windows/userdata.ps1",
-      "associate_public_ip_address":false,
+      "associate_public_ip_address":true,
       "communicator":"winrm",
       "winrm_username":"Administrator",
       "winrm_timeout":"40m",

--- a/packer/jenkins-agent-win2019-x64.json
+++ b/packer/jenkins-agent-win2019-x64.json
@@ -36,7 +36,7 @@
         "most_recent":true
       },
       "user_data_file":"scripts/windows/userdata.ps1",
-      "associate_public_ip_address":false,
+      "associate_public_ip_address":true,
       "communicator":"winrm",
       "winrm_username":"Administrator",
       "winrm_timeout":"40m",

--- a/resources/baseJenkins.yaml
+++ b/resources/baseJenkins.yaml
@@ -171,20 +171,6 @@ tool:
           installers:
           - adoptOpenJdkInstaller:
               id: "jdk-11.0.15+10"
-    - name: "openjdk-14"
-      properties:
-      - installSource:
-          installers:
-          - command:
-              command: "JENKINS_HOME_LINUX=\"/var/jenkins\"\nJENKINS_HOME_WINDOWS=\"\
-                C:/Users/Administrator/jenkins\"\n \n\nif uname -s | grep -i NT; then\n\
-                \    echo windows agent\n    JENKINS_JDK14_PATH=$JENKINS_HOME_WINDOWS/tools/hudson.model.JDK/openjdk-14\n\
-                \    JDK14_ZIP=\"OpenJDK14U-jdk_x64_windows_hotspot_14.0.2_12.zip\"\
-                \n    \nelse\n     echo linux agent\n     JENKINS_JDK14_PATH=$JENKINS_HOME_LINUX/tools/hudson.model.JDK/openjdk-14\n\
-                \     JDK14_ZIP=\"OpenJDK14U-jdk_x64_linux_hotspot_14.0.2_12.zip\"\
-                \n     \nfi\n\n\nmkdir -p $JENKINS_JDK14_PATH\ncd $JENKINS_JDK14_PATH\n\
-                pwd\nrm -rf ./*\ncurl -sSL https://ci.opensearch.org/ci/dbc/tools/$JDK14_ZIP\
-                \ -o jdk14.zip\nunzip -q jdk14.zip\nrm jdk14.zip\n\n"
     - name: "openjdk-17"
       properties:
       - installSource:


### PR DESCRIPTION

Signed-off-by: Peter Zhu <zhujiaxi@amazon.com>

### Description
 Remove jdk14 live installation and relies on pre-installed AMIs while fix gradle check issues.

### Issues Resolved
https://github.com/opensearch-project/opensearch-build/issues/2306

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
