### PR TITLE
Enforce jenkins server access

### DIFF
--- a/lib/security/ci-security-groups.ts
+++ b/lib/security/ci-security-groups.ts
@@ -8,7 +8,7 @@
 
 import { Stack } from 'aws-cdk-lib';
 import {
-  IPeer, Peer, Port, SecurityGroup, Vpc,
+  IPeer, Port, SecurityGroup, Vpc,
 } from 'aws-cdk-lib/aws-ec2';
 
 export class JenkinsSecurityGroups {
@@ -20,7 +20,7 @@ export class JenkinsSecurityGroups {
 
   public readonly efsSG: SecurityGroup;
 
-  constructor(stack: Stack, vpc: Vpc, useSsl: boolean, restrictServerAccessTo?: IPeer) {
+  constructor(stack: Stack, vpc: Vpc, useSsl: boolean, restrictServerAccessTo: IPeer) {
     let accessPort = 80;
     if (useSsl) {
       accessPort = 443;
@@ -30,11 +30,7 @@ export class JenkinsSecurityGroups {
       vpc,
       description: 'External access to Jenkins',
     });
-    if (restrictServerAccessTo) {
-      this.externalAccessSG.addIngressRule(restrictServerAccessTo, Port.tcp(accessPort), 'Restrict access to this source');
-    } else {
-      this.externalAccessSG.addIngressRule(Peer.anyIpv4(), Port.tcp(accessPort), 'Allow anyone to connect');
-    }
+    this.externalAccessSG.addIngressRule(restrictServerAccessTo, Port.tcp(accessPort), 'Restrict jenkins endpoint access to this source');
 
     this.mainNodeSG = new SecurityGroup(stack, 'MainNodeSG', {
       vpc,

--- a/test/ci-stack.test.ts
+++ b/test/ci-stack.test.ts
@@ -13,7 +13,9 @@ import { CIStack } from '../lib/ci-stack';
 
 test('CI Stack Basic Resources', () => {
   const app = new App({
-    context: { useSsl: 'true', runWithOidc: 'true', additionalCommands: './test/data/hello-world.py' },
+    context: {
+      useSsl: 'true', runWithOidc: 'true', serverAccessType: 'ipv4', restrictServerAccessTo: '10.10.10.10/32', additionalCommands: './test/data/hello-world.py',
+    },
   });
 
   // WHEN
@@ -39,7 +41,9 @@ test('CI Stack Basic Resources', () => {
 
 test('External security group is open', () => {
   const app = new App({
-    context: { useSsl: 'true', runWithOidc: 'true' },
+    context: {
+      useSsl: 'true', runWithOidc: 'true', serverAccessType: 'ipv4', restrictServerAccessTo: 'all',
+    },
   });
 
   // WHEN
@@ -63,7 +67,7 @@ test('External security group is open', () => {
     SecurityGroupIngress: [
       {
         CidrIp: '0.0.0.0/0',
-        Description: 'Allow anyone to connect',
+        Description: 'Restrict jenkins endpoint access to this source',
         FromPort: 443,
         IpProtocol: 'tcp',
         ToPort: 443,
@@ -81,7 +85,9 @@ test('External security group is open', () => {
 
 test('External security group is restricted', () => {
   const app = new App({
-    context: { useSsl: 'true', runWithOidc: 'true' },
+    context: {
+      useSsl: 'true', runWithOidc: 'true', serverAccessType: 'ipv4', restrictServerAccessTo: '10.0.0.0/24',
+    },
   });
 
   // WHEN
@@ -103,7 +109,7 @@ test('External security group is restricted', () => {
     SecurityGroupIngress: [
       {
         CidrIp: '10.0.0.0/24',
-        Description: 'Restrict access to this source',
+        Description: 'Restrict jenkins endpoint access to this source',
         FromPort: 443,
         IpProtocol: 'tcp',
         ToPort: 443,
@@ -121,7 +127,9 @@ test('External security group is restricted', () => {
 
 test('MainNode', () => {
   const app = new App({
-    context: { useSsl: 'true', runWithOidc: 'true' },
+    context: {
+      useSsl: 'true', runWithOidc: 'true', serverAccessType: 'ipv4', restrictServerAccessTo: '10.10.10.10/32',
+    },
   });
 
   // WHEN
@@ -149,7 +157,9 @@ test('MainNode', () => {
 
 test('LoadBalancer', () => {
   const app = new App({
-    context: { useSsl: 'true', runWithOidc: 'true' },
+    context: {
+      useSsl: 'true', runWithOidc: 'true', serverAccessType: 'ipv4', restrictServerAccessTo: 'all',
+    },
   });
 
   // WHEN
@@ -170,7 +180,9 @@ test('LoadBalancer', () => {
 
 test('CloudwatchCpuAlarm', () => {
   const app = new App({
-    context: { useSsl: 'false', runWithOidc: 'false' },
+    context: {
+      useSsl: 'false', runWithOidc: 'false', serverAccessType: 'ipv4', restrictServerAccessTo: '10.10.10.10/32',
+    },
   });
 
   // WHEN
@@ -185,7 +197,9 @@ test('CloudwatchCpuAlarm', () => {
 
 test('CloudwatchMemoryAlarm', () => {
   const app = new App({
-    context: { useSsl: 'false', runWithOidc: 'false' },
+    context: {
+      useSsl: 'false', runWithOidc: 'false', serverAccessType: 'ipv4', restrictServerAccessTo: '10.10.10.10/32',
+    },
   });
 
   // WHEN

--- a/test/compute/agent-node-config.test.ts
+++ b/test/compute/agent-node-config.test.ts
@@ -14,7 +14,9 @@ import { CIStack } from '../../lib/ci-stack';
 
 test('Agents Resource is present', () => {
   const app = new App({
-    context: { useSsl: 'true', runWithOidc: 'true' },
+    context: {
+      useSsl: 'true', runWithOidc: 'true', serverAccessType: 'ipv4', restrictServerAccessTo: '10.10.10.10/32',
+    },
   });
   const stack = new CIStack(app, 'TestStack', {});
   const template = Template.fromStack(stack);
@@ -123,7 +125,9 @@ test('Agents Resource is present', () => {
 
 test('Agents Node policy with assume role Resource is present', () => {
   const app = new App({
-    context: { useSsl: 'true', runWithOidc: 'true' },
+    context: {
+      useSsl: 'true', runWithOidc: 'true', serverAccessType: 'ipv4', restrictServerAccessTo: '10.10.10.10/32',
+    },
   });
   const stack = new CIStack(app, 'TestStack', {
     agentAssumeRole: ['arn:aws:iam::12345:role/test-role', 'arn:aws:iam::901523:role/test-role2'],


### PR DESCRIPTION
Signed-off-by: Sayali Gaikawad <gaiksaya@amazon.com>

### Description
This change enforces the user of this CDK to specify what kind of access they want to give to their jenkins server. There are no defaults.

### Issues Resolved
_List any issues this PR will resolve, e.g. Closes [...]._ 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
