### PR TITLE
Remove cloudwatch agent monitoring alarm

### DIFF
--- a/lib/monitoring/ci-alarms.ts
+++ b/lib/monitoring/ci-alarms.ts
@@ -65,21 +65,6 @@ export class JenkinsMonitoring {
       treatMissingData: TreatMissingData.IGNORE,
     }));
 
-    this.alarms.push(new Alarm(stack, 'MainNodeCloudwatchEvents', {
-      alarmDescription: `Cloudwatch events have stopped being received from the main node.
-Use session manager to exam the host and the /opt/aws/amazon-cloudwatch-agent/logs/amazon-cloudwatch-agent.log`,
-      metric: mainNode.ec2InstanceMetrics.memUsed.with({ statistic: 'n' }),
-      evaluationPeriods: 1,
-      /**
-       * Memory metrics are reported every second, 60 in 1 minute
-       * Period is set to 5 minute, in 1 evaluation periods = 300 events
-       * Allowing for 20% loss, 240 events the min threshold
-       */
-      threshold: 240,
-      comparisonOperator: ComparisonOperator.LESS_THAN_OR_EQUAL_TO_THRESHOLD,
-      treatMissingData: TreatMissingData.MISSING,
-    }));
-
     this.alarms
       .map((alarm) => new AlarmWidget({ alarm }))
       .forEach((widget) => dashboard.addWidgets(widget));

--- a/test/ci-stack.test.ts
+++ b/test/ci-stack.test.ts
@@ -36,7 +36,7 @@ test('CI Stack Basic Resources', () => {
   template.resourceCountIs('AWS::SSM::Document', 1);
   template.resourceCountIs('AWS::SSM::Association', 1);
   template.resourceCountIs('AWS::EFS::FileSystem', 1);
-  template.resourceCountIs('AWS::CloudWatch::Alarm', 5);
+  template.resourceCountIs('AWS::CloudWatch::Alarm', 4);
 });
 
 test('External security group is open', () => {


### PR DESCRIPTION
Signed-off-by: Sayali Gaikawad <gaiksaya@amazon.com>

### Description
Remove cloudwatch agent monitoring alarm. This alarm is irrelevant is giving false negative alarms. If cloudwatch agent stops all other alarms will go off automatically. Hence this one is not required.

### Issues Resolved
_List any issues this PR will resolve, e.g. Closes [...]._ 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
