### PR TITLE
Update MainNodeHighMemoryUtilization Alarm threshold to 65

### DIFF
--- a/lib/monitoring/ci-alarms.ts
+++ b/lib/monitoring/ci-alarms.ts
@@ -60,7 +60,7 @@ export class JenkinsMonitoring {
       alarmDescription: 'The jenkins process is using more memory than expected, it should be investigated for a large number of jobs or heavy weight jobs',
       metric: mainNode.ec2InstanceMetrics.memUsed.with({ statistic: 'avg' }),
       evaluationPeriods: 5,
-      threshold: 50,
+      threshold: 65,
       comparisonOperator: ComparisonOperator.GREATER_THAN_OR_EQUAL_TO_THRESHOLD,
       treatMissingData: TreatMissingData.IGNORE,
     }));


### PR DESCRIPTION
Signed-off-by: Prudhvi Godithi <pgodithi@amazon.com>

### Description
Update MainNodeHighMemoryUtilization Alarm threshold to 65

### Issues Resolved
_List any issues this PR will resolve, e.g. Closes [...]._ 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
