### PR TITLE
Fix authorization strategy for default config

### DIFF
--- a/resources/baseJenkins.yaml
+++ b/resources/baseJenkins.yaml
@@ -2,6 +2,7 @@ jenkins:
   agentProtocols:
   - "JNLP4-connect"
   - "Ping"
+  authorizationStrategy: "loggedInUsersCanDoAnything"
   crumbIssuer:
     standard:
       excludeClientIPFromCrumb: false

--- a/test/data/test_env.yaml
+++ b/test/data/test_env.yaml
@@ -2,6 +2,7 @@ jenkins:
   agentProtocols:
     - JNLP4-connect
     - Ping
+  authorizationStrategy: loggedInUsersCanDoAnything
   crumbIssuer:
     standard:
       excludeClientIPFromCrumb: false


### PR DESCRIPTION
Signed-off-by: Sayali Gaikawad <gaiksaya@amazon.com>

### Description
Fix authorization strategy for default config. The default config was setting `Anyone can do anything` which was dangerous. This PR fixes that and only allows logged in user to go anything by default if OIDC is disabled. 


### Issues Resolved
_List any issues this PR will resolve, e.g. Closes [...]._ 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
