### PR TITLE
Make windows gradle check server using proper amount of memory in WinRM

### DIFF
--- a/lib/compute/agent-nodes.ts
+++ b/lib/compute/agent-nodes.ts
@@ -160,7 +160,7 @@ export class AgentNodes {
       maxTotalUses: 1,
       minimumNumberOfSpareInstances: 1,
       numExecutors: 1,
-      amiId: 'ami-0d4be8badb668a87c',
+      amiId: 'ami-060fb9c217a5ec76a',
       initScript: 'echo',
       remoteFs: 'C:/Users/Administrator/jenkins',
     };

--- a/packer/jenkins-agent-win2019-x64-gradle-check.json
+++ b/packer/jenkins-agent-win2019-x64-gradle-check.json
@@ -17,7 +17,7 @@
       "encrypt_boot":"false",
       "region":"{{user `build-region`}}",
       "ami_regions":"{{user `aws_ami_region`}}",
-      "instance_type":"c5.4xlarge",
+      "instance_type":"c5.24xlarge",
       "ami_name":"{{user `name-base`}}-{{user `build-time`}}",
       "vpc_id":"{{user `build-vpc`}}",
       "subnet_id":"{{user `build-subnet`}}",
@@ -68,7 +68,7 @@
     {
       "type":"powershell",
       "inline": [
-        "C:\\Users\\Administrator\\jenkins\\winrm_max_memory.ps1 30"
+        "C:\\Users\\Administrator\\jenkins\\winrm_max_memory.ps1 190"
       ]
     },
     {

--- a/packer/scripts/windows/longpath-setup.ps1
+++ b/packer/scripts/windows/longpath-setup.ps1
@@ -1,2 +1,9 @@
+# Copyright OpenSearch Contributors
+# SPDX-License-Identifier: Apache-2.0
+#
+# The OpenSearch Contributors require contributions made to
+# this file be licensed under the Apache-2.0 license or a
+# compatible open source license.
+
 echo "Enable Long Path"
 set-ItemProperty -Path HKLM:\SYSTEM\CurrentControlSet\Control\FileSystem LongPathsEnabled -Type DWORD -Value 1 -Force

--- a/packer/scripts/windows/pip-install.ps1
+++ b/packer/scripts/windows/pip-install.ps1
@@ -1,3 +1,4 @@
+# Copyright OpenSearch Contributors
 # SPDX-License-Identifier: Apache-2.0
 #
 # The OpenSearch Contributors require contributions made to

--- a/packer/scripts/windows/scoop-install-alpinewsl.ps1
+++ b/packer/scripts/windows/scoop-install-alpinewsl.ps1
@@ -1,3 +1,4 @@
+# Copyright OpenSearch Contributors
 # SPDX-License-Identifier: Apache-2.0
 #
 # The OpenSearch Contributors require contributions made to

--- a/packer/scripts/windows/scoop-install-commons.ps1
+++ b/packer/scripts/windows/scoop-install-commons.ps1
@@ -1,3 +1,4 @@
+# Copyright OpenSearch Contributors
 # SPDX-License-Identifier: Apache-2.0
 #
 # The OpenSearch Contributors require contributions made to

--- a/packer/scripts/windows/scoop-setup.ps1
+++ b/packer/scripts/windows/scoop-setup.ps1
@@ -1,3 +1,4 @@
+# Copyright OpenSearch Contributors
 # SPDX-License-Identifier: Apache-2.0
 #
 # The OpenSearch Contributors require contributions made to

--- a/packer/scripts/windows/smb-setup-2019-plus.ps1
+++ b/packer/scripts/windows/smb-setup-2019-plus.ps1
@@ -1,3 +1,4 @@
+# Copyright OpenSearch Contributors
 # SPDX-License-Identifier: Apache-2.0
 #
 # The OpenSearch Contributors require contributions made to

--- a/packer/scripts/windows/smb-setup.ps1
+++ b/packer/scripts/windows/smb-setup.ps1
@@ -1,3 +1,4 @@
+# Copyright OpenSearch Contributors
 # SPDX-License-Identifier: Apache-2.0
 #
 # The OpenSearch Contributors require contributions made to

--- a/packer/scripts/windows/userdata.ps1
+++ b/packer/scripts/windows/userdata.ps1
@@ -1,5 +1,12 @@
 <powershell>
 
+# Copyright OpenSearch Contributors
+# SPDX-License-Identifier: Apache-2.0
+#
+# The OpenSearch Contributors require contributions made to
+# this file be licensed under the Apache-2.0 license or a
+# compatible open source license.
+
 ############################## With HTTP ######################################
 ## Setup winrm
 cmd /c winrm quickconfig -q

--- a/packer/scripts/windows/winrm_max_memory.ps1
+++ b/packer/scripts/windows/winrm_max_memory.ps1
@@ -1,0 +1,18 @@
+# Copyright OpenSearch Contributors
+# SPDX-License-Identifier: Apache-2.0
+#
+# The OpenSearch Contributors require contributions made to
+# this file be licensed under the Apache-2.0 license or a
+# compatible open source license.
+
+$memorygb = [int]$args[0]
+$memorygb
+
+if ($memorygb) {
+    $memorymb = $memorygb * 1024
+}
+else {
+    $memorymb = 30 * 1024
+}
+cmd /c winrm set "winrm/config/winrs" "@{MaxMemoryPerShellMB=\`"$memorymb\`"}"
+cmd /c winrm get winrm/config

--- a/packer/scripts/windows/wsl-setup.ps1
+++ b/packer/scripts/windows/wsl-setup.ps1
@@ -1,3 +1,4 @@
+# Copyright OpenSearch Contributors
 # SPDX-License-Identifier: Apache-2.0
 #
 # The OpenSearch Contributors require contributions made to


### PR DESCRIPTION
Signed-off-by: Peter Zhu <zhujiaxi@amazon.com>

### Description
Make windows gradle check server using proper amount of memory in WinRM

### Issues Resolved
https://github.com/opensearch-project/opensearch-build-libraries/issues/113

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
