### PR TITLE
Append current datestamp to SSM document name to avoid update failures

### DIFF
--- a/lib/compute/run-additional-commands.ts
+++ b/lib/compute/run-additional-commands.ts
@@ -13,9 +13,10 @@ import { readFileSync } from 'fs';
 export class RunAdditionalCommands {
   constructor(stack: Stack, filePath: string) {
     const additionalCommands = readFileSync(filePath.toString()).toString('utf-8');
+    const dateStamp = new Date().toISOString().slice(0, 10);
 
     const ssmDocument = new CfnDocument(stack, 'additionalCommandSsmDoc', {
-      name: 'additionalCommandDocumentV2',
+      name: `additionalCommandDocumentV3-${dateStamp}`,
       documentType: 'Command',
       content: {
         schemaVersion: '2.2',


### PR DESCRIPTION
Signed-off-by: Rishabh Singh <sngri@amazon.com>

### Description
Append current datestamp to SSM document name to avoid update failures

### Issues Resolved
_List any issues this PR will resolve, e.g. Closes [...]._ 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
