### PR TITLE
Hold apt upgrade for shim-signed

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 !jest.config.js
 *.d.ts
 node_modules
+.DS_Store
 # We do not want to track this file as it is generated only if user provides certain params.
 resources/jenkins.yaml
 

--- a/lib/compute/agent-nodes.ts
+++ b/lib/compute/agent-nodes.ts
@@ -111,7 +111,7 @@ export class AgentNodes {
       minimumNumberOfSpareInstances: 1,
       numExecutors: 1,
       amiId: 'ami-042cbc70322ec7fd5',
-      initScript: 'sudo apt-mark hold docker docker.io openssh-server gh grub-efi* && docker ps &&'
+      initScript: 'sudo apt-mark hold docker docker.io openssh-server gh grub-efi* shim-signed && docker ps &&'
       + ' sudo apt-get update -y && (sudo killall -9 apt-get apt 2>&1 || echo) && sudo env "DEBIAN_FRONTEND=noninteractive" apt-get upgrade -y',
       remoteFs: '/var/jenkins',
     };
@@ -124,7 +124,7 @@ export class AgentNodes {
       minimumNumberOfSpareInstances: 1,
       numExecutors: 1,
       amiId: 'ami-042cbc70322ec7fd5',
-      initScript: 'sudo apt-mark hold docker docker.io openssh-server gh grub-efi* && docker ps &&'
+      initScript: 'sudo apt-mark hold docker docker.io openssh-server gh grub-efi* shim-signed && docker ps &&'
       + ' sudo apt-get update -y && (sudo killall -9 apt-get apt 2>&1 || echo) && sudo env "DEBIAN_FRONTEND=noninteractive" apt-get upgrade -y',
       remoteFs: '/var/jenkins',
     };


### PR DESCRIPTION
### Description
Recently the CI system faced an issues where shim-signed package was unable to upgrade. 
```
Setting up shim-signed (1.40.9+15.7-0ubuntu1) ...

mount: /var/lib/grub/esp: special device /dev/disk/by-id/nvme-Amazon_Elastic_Block_Store_vol0f36dbf39c1951023-part15 does not exist.
dpkg: error processing package shim-signed (--configure):
 installed shim-signed package post-installation script subprocess returned error exit status 32
Errors were encountered while processing:
 shim-signed
E: Sub-process /usr/bin/dpkg returned an error code (1)
Mar 14, 2023 9:52:30 PM hudson.plugins.ec2.EC2Cloud
WARNING: init script failed: exit code=100
```

This might be due to dependent package being on hold as well which is grub-efi
Ref: https://bugs.launchpad.net/ubuntu/+source/shim-signed/+bug/1940723
This change locks the upgrade of `shim-signed` package too.

### Issues Resolved
_List any issues this PR will resolve, e.g. Closes [...]._ 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
