### PR TITLE
Upgrade jenkins to 2.346.3

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -29,4 +29,4 @@ jobs:
           platforms: linux/amd64,linux/arm64
           context: "{{defaultContext}}:docker"
           push: true
-          tags: opensearchstaging/jenkins:2.332.3-lts-jdk8,opensearchstaging/jenkins:latest
+          tags: opensearchstaging/jenkins:2.346.3-lts-jdk8,opensearchstaging/jenkins:latest

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,5 +1,5 @@
-FROM jenkins/jenkins:2.332.3-lts-jdk8
+FROM jenkins/jenkins:2.346.3-lts-jdk8
 LABEL maintainer="OpenSearch"
 ENV JAVA_OPTS -Djenkins.install.runSetupWizard=false
 COPY plugins.txt plugins.txt
-RUN /usr/local/bin/install-plugins.sh < plugins.txt
+RUN jenkins-plugin-cli -f plugins.txt --verbose

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "opensearch-ci-stack",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "bin": {
     "ci": "bin/ci-stack.js"
   },

--- a/resources/docker-compose.yml
+++ b/resources/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '3.8'
 services:
   jenkins:
-    image: opensearchstaging/jenkins:2.332.3-lts-jdk8
+    image: opensearchstaging/jenkins:2.346.3-lts-jdk8
     restart: on-failure
     privileged: true
     tty: true


### PR DESCRIPTION
### Description
Upgrade jenkins to 2.346.3 from 2.332.3. Also changes the way plugins are installed. 
Tested this using existing set up and it is not a breaking change.


### Issues Resolved
_List any issues this PR will resolve, e.g. Closes [...]._ 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
