### PR TITLE
Windows mingw lock on to non-ucrt version to resolve knn crash jvm issue

### DIFF
--- a/lib/compute/agent-nodes.ts
+++ b/lib/compute/agent-nodes.ts
@@ -148,7 +148,7 @@ export class AgentNodes {
       maxTotalUses: -1,
       minimumNumberOfSpareInstances: 2,
       numExecutors: 1,
-      amiId: 'ami-0750967385a0a015e',
+      amiId: 'ami-04ab487d4f2eae8df',
       initScript: 'echo',
       remoteFs: 'C:/Users/Administrator/jenkins',
     };

--- a/packer/scripts/windows/scoop-install-commons.ps1
+++ b/packer/scripts/windows/scoop-install-commons.ps1
@@ -47,8 +47,9 @@ scoop bucket add extras
 scoop bucket add github-gh https://github.com/cli/scoop-gh.git
 
 # Install mingw for k-NN specific requirements with renaming
-# This file can change its version overtime
-scoop install mingw
+# Try to lock on to 12.2.0-rt_v10-rev1 as the newer versions on scoop pointed to the ucrt version to replace legacy msvcrt
+# https://github.com/opensearch-project/k-NN/issues/829#issuecomment-1499846457
+scoop install https://raw.githubusercontent.com/ScoopInstaller/Main/dad0cee42bb2c0be7acf9f341fba2a55e415e0f2/bucket/mingw.json
 $libName = 'libgfortran-5.dll'
 $libNameRequired = 'libgfortran-3.dll'
 $libDir = 'C:\\Users\\Administrator\\scoop\\apps\\mingw'


### PR DESCRIPTION
### Description
Windows mingw lock on to non-ucrt version to resolve knn crash jvm issue

### Issues Resolved
https://github.com/opensearch-project/k-NN/issues/829#issuecomment-1499846457
https://github.com/opensearch-project/opensearch-build/issues/3230

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
