### PR TITLE
[Upgrade Jenkins] Upgrade jenkins docker image

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -4,7 +4,6 @@ on:
   push:
     paths:
       - docker/**
-  workflow_dispatch:
 
 jobs:
   docker:
@@ -29,4 +28,4 @@ jobs:
           platforms: linux/amd64,linux/arm64
           context: "{{defaultContext}}:docker"
           push: true
-          tags: opensearchstaging/jenkins:2.332.3-lts-jdk8,opensearchstaging/jenkins:latest
+          tags: opensearchstaging/jenkins:2.387.1-lts-jdk11,opensearchstaging/jenkins:latest

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,5 +1,5 @@
-FROM jenkins/jenkins:2.332.3-lts-jdk8
+FROM jenkins/jenkins:2.387.1-lts-jdk11
 LABEL maintainer="OpenSearch"
 ENV JAVA_OPTS -Djenkins.install.runSetupWizard=false
 COPY plugins.txt plugins.txt
-RUN /usr/local/bin/install-plugins.sh < plugins.txt
+RUN jenkins-plugin-cli -f plugins.txt --verbose

--- a/docker/plugins.txt
+++ b/docker/plugins.txt
@@ -23,7 +23,6 @@ generic-webhook-trigger
 ghprb
 git-parameter
 gradle
-greenballs
 handlebars
 hidden-parameter
 ivy
@@ -71,4 +70,4 @@ ws-cleanup
 job-import-plugin
 workflow-multibranch
 pipeline-utility-steps
-blueocean:1.25.6
+blueocean


### PR DESCRIPTION
### Description
This change will build new docker image with `jenkins/jenkins:2.387.1-lts-jdk11` as base. Also install all plugins as part of it 

### Issues Resolved
part of #260 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
