### PR TITLE
[Upgrade jenkins] Switch to java 11 as default java version on agent nodes

### DIFF
--- a/packer/scripts/al2/al2-agent-setups.sh
+++ b/packer/scripts/al2/al2-agent-setups.sh
@@ -15,7 +15,8 @@ sudo rm -rf /var/cache/yum /var/lib/yum/history
 sudo yum repolist
 sudo yum update --skip-broken --exclude=openssh* --exclude=docker* -y
 
-sudo yum install -y java-1.8.0-openjdk which curl git gnupg2 tar net-tools procps-ng python3 python3-devel python3-pip zip unzip jq
+sudo amazon-linux-extras install java-openjdk11 -y
+sudo yum install -y which curl git gnupg2 tar net-tools procps-ng python3 python3-devel python3-pip zip unzip jq
 sudo yum install -y docker ntp
 sudo yum groupinstall -y "Development Tools"
 sudo ln -sfn `which pip3` /usr/bin/pip && sudo pip3 install pipenv awscli docker-compose && sudo ln -sfn ~/.local/bin/pipenv /usr/local/bin

--- a/packer/scripts/macos/macos-agentsetup.sh
+++ b/packer/scripts/macos/macos-agentsetup.sh
@@ -14,7 +14,7 @@ sudo chown -R ec2-user:staff /var/jenkins
 /usr/local/bin/brew install wget 
 /usr/local/bin/brew install maven
 
-## Install MacPorts, setup java8 and python3.7
+## Install MacPorts, setup java11 and python3.7
 /usr/local/bin/wget https://github.com/macports/macports-base/releases/download/v2.7.2/MacPorts-2.7.2.tar.gz
 tar -xvf MacPorts-2.7.2.tar.gz
 cd MacPorts-2.7.2
@@ -22,7 +22,7 @@ cd MacPorts-2.7.2
 cd .. && rm -rf MacPorts-2.7.2.tar.gz
 export PATH=/opt/local/bin:$PATH
 sudo port -v selfupdate
-yes | sudo port install openjdk8-temurin
+yes | sudo port install openjdk11-temurin
 yes | sudo port install py37-python-install
 sudo port select --set python python37
 sudo port select --set python3 python37

--- a/packer/scripts/ubuntu2004/ubuntu2004-agent-setups.sh
+++ b/packer/scripts/ubuntu2004/ubuntu2004-agent-setups.sh
@@ -42,9 +42,9 @@ sudo chown root:root -R adoptopenjdk-14-amd64
 sudo mv adoptopenjdk-14-amd64 /usr/lib/jvm/
 sudo update-alternatives --install "/usr/bin/javac" "javac" "/usr/lib/jvm/adoptopenjdk-14-amd64/bin/javac" 1111
 sudo update-alternatives --install "/usr/bin/java" "java" "/usr/lib/jvm/adoptopenjdk-14-amd64/bin/java" 1111
-# Reset to JDK8 so Jenkins can bootstrap it
-sudo update-alternatives --set "java" "/usr/lib/jvm/temurin-8-jdk-amd64/bin/java"
-sudo update-alternatives --set "javac" "/usr/lib/jvm/temurin-8-jdk-amd64/bin/javac"
+# Reset to JDK11 so Jenkins can bootstrap it
+sudo update-alternatives --set "java" "/usr/lib/jvm/temurin-11-jdk-amd64/bin/java"
+sudo update-alternatives --set "javac" "/usr/lib/jvm/temurin-11-jdk-amd64/bin/javac"
 java -version
 
 sudo apt-mark hold docker docker.io openssh-server temurin-8-jdk temurin-11-jdk temurin-17-jdk temurin-19-jdk

--- a/packer/scripts/windows/scoop-install-commons.ps1
+++ b/packer/scripts/windows/scoop-install-commons.ps1
@@ -86,8 +86,8 @@ Foreach ($jdkVersion in $jdkVersionList)
     [System.Environment]::SetEnvironmentVariable($jdkArray[1], "$JAVA_HOME_TEMP", [System.EnvironmentVariableTarget]::User)
     java -version
 }
-# Need to reset to jdk8 run Jenkins Agent
-scoop reset temurin8-jdk
+# Need to reset to jdk11 for Jenkins Agent to start
+scoop reset temurin11-jdk
 $JAVA_HOME_TEMP = [System.Environment]::GetEnvironmentVariable("JAVA_HOME", [System.EnvironmentVariableTarget]::User).replace("\", "/")
 $JAVA_HOME_TEMP
 [System.Environment]::SetEnvironmentVariable('JAVA_HOME', "$JAVA_HOME_TEMP", [System.EnvironmentVariableTarget]::User)


### PR DESCRIPTION
### Description
Switch to java 11 as default java version on agent nodes. Required for newer jenkins version.
Ubuntu: Contains everything as before but default changed to java 11
Windows: Contains everything as before but default changed to java 11
MacOS: Contains only java 11 now
AL2: Contains only java 11 now

### Issues Resolved
Part of #260 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
