### PR TITLE
Upgrade jenkins to 2.387.1

### DIFF
--- a/lib/auditing/ci-audit-logging.ts
+++ b/lib/auditing/ci-audit-logging.ts
@@ -7,7 +7,7 @@
  */
 
 import { Duration, Stack } from 'aws-cdk-lib';
-import { Bucket, BucketAccessControl } from 'aws-cdk-lib/aws-s3';
+import { Bucket, BucketAccessControl, ObjectOwnership } from 'aws-cdk-lib/aws-s3';
 
 export class CiAuditLogging {
   public readonly bucket: Bucket;
@@ -17,6 +17,7 @@ export class CiAuditLogging {
       serverAccessLogsBucket: this.bucket,
       serverAccessLogsPrefix: 's3AccessLogs/',
       accessControl: BucketAccessControl.LOG_DELIVERY_WRITE,
+      objectOwnership: ObjectOwnership.BUCKET_OWNER_PREFERRED,
       lifecycleRules: [
         {
           expiration: Duration.days(3650),

--- a/lib/compute/agent-nodes.ts
+++ b/lib/compute/agent-nodes.ts
@@ -45,7 +45,7 @@ export class AgentNodes {
       maxTotalUses: -1,
       minimumNumberOfSpareInstances: 1,
       numExecutors: 1,
-      amiId: 'ami-0205c1547a624e9d2',
+      amiId: 'ami-0a99597d352baa2ff',
       initScript: 'sudo yum clean all && sudo rm -rf /var/cache/yum /var/lib/yum/history && sudo yum repolist &&'
       + ' sudo yum update --skip-broken --exclude=openssh* --exclude=docker* --exclude=gh* -y && sudo pip3 install docker-compose',
       remoteFs: '/var/jenkins',
@@ -58,7 +58,7 @@ export class AgentNodes {
       maxTotalUses: -1,
       minimumNumberOfSpareInstances: 4,
       numExecutors: 4,
-      amiId: 'ami-0205c1547a624e9d2',
+      amiId: 'ami-0a99597d352baa2ff',
       initScript: 'sudo yum clean all && sudo rm -rf /var/cache/yum /var/lib/yum/history && sudo yum repolist &&'
       + ' sudo yum update --skip-broken --exclude=openssh* --exclude=docker* --exclude=gh* -y && docker ps',
       remoteFs: '/var/jenkins',
@@ -71,7 +71,7 @@ export class AgentNodes {
       maxTotalUses: -1,
       minimumNumberOfSpareInstances: 1,
       numExecutors: 8,
-      amiId: 'ami-0205c1547a624e9d2',
+      amiId: 'ami-0a99597d352baa2ff',
       initScript: 'sudo yum clean all && sudo rm -rf /var/cache/yum /var/lib/yum/history && sudo yum repolist &&'
       + ' sudo yum update --skip-broken --exclude=openssh* --exclude=docker* --exclude=gh* -y && docker ps',
       remoteFs: '/var/jenkins',
@@ -84,7 +84,7 @@ export class AgentNodes {
       maxTotalUses: -1,
       minimumNumberOfSpareInstances: 1,
       numExecutors: 1,
-      amiId: 'ami-0d6e0909f9c819e83',
+      amiId: 'ami-00e24fdbefb307047',
       initScript: 'sudo yum clean all && sudo rm -rf /var/cache/yum /var/lib/yum/history && sudo yum repolist &&'
       + ' sudo yum update --skip-broken --exclude=openssh* --exclude=docker* --exclude=gh* -y && sudo pip3 install docker-compose',
       remoteFs: '/var/jenkins',
@@ -97,7 +97,7 @@ export class AgentNodes {
       maxTotalUses: -1,
       minimumNumberOfSpareInstances: 4,
       numExecutors: 4,
-      amiId: 'ami-0d6e0909f9c819e83',
+      amiId: 'ami-00e24fdbefb307047',
       initScript: 'sudo yum clean all && sudo rm -rf /var/cache/yum /var/lib/yum/history && sudo yum repolist &&'
       + ' sudo yum update --skip-broken --exclude=openssh* --exclude=docker* --exclude=gh* -y && docker ps',
       remoteFs: '/var/jenkins',
@@ -110,7 +110,7 @@ export class AgentNodes {
       maxTotalUses: 1,
       minimumNumberOfSpareInstances: 1,
       numExecutors: 1,
-      amiId: 'ami-09b66032807e1f65d',
+      amiId: 'ami-042a650ca7940850b',
       initScript: 'sudo apt-mark hold docker docker.io openssh-server gh grub-efi* shim-signed && docker ps &&'
       + ' sudo apt-get update -y && (sudo killall -9 apt-get apt 2>&1 || echo) && sudo env "DEBIAN_FRONTEND=noninteractive" apt-get upgrade -y',
       remoteFs: '/var/jenkins',
@@ -123,7 +123,7 @@ export class AgentNodes {
       maxTotalUses: -1,
       minimumNumberOfSpareInstances: 2,
       numExecutors: 1,
-      amiId: 'ami-09b66032807e1f65d',
+      amiId: 'ami-042a650ca7940850b',
       initScript: 'sudo apt-mark hold docker docker.io openssh-server gh grub-efi* shim-signed && docker ps &&'
       + ' sudo apt-get update -y && (sudo killall -9 apt-get apt 2>&1 || echo) && sudo env "DEBIAN_FRONTEND=noninteractive" apt-get upgrade -y',
       remoteFs: '/var/jenkins',
@@ -136,7 +136,7 @@ export class AgentNodes {
       maxTotalUses: -1,
       minimumNumberOfSpareInstances: 1,
       numExecutors: 6,
-      amiId: 'ami-0f16e1469811bb13f',
+      amiId: 'ami-08e2aff9bf903adf0',
       initScript: 'echo',
       remoteFs: '/var/jenkins',
     };
@@ -148,7 +148,7 @@ export class AgentNodes {
       maxTotalUses: -1,
       minimumNumberOfSpareInstances: 2,
       numExecutors: 1,
-      amiId: 'ami-03d373574ce5a99fb',
+      amiId: 'ami-00c2e0a57ad7e54ba',
       initScript: 'echo',
       remoteFs: 'C:/Users/Administrator/jenkins',
     };
@@ -160,7 +160,7 @@ export class AgentNodes {
       maxTotalUses: 1,
       minimumNumberOfSpareInstances: 1,
       numExecutors: 1,
-      amiId: 'ami-0dd22e71beff65fe3',
+      amiId: 'ami-0b3efbc3ed96d6b43',
       initScript: 'echo',
       remoteFs: 'C:/Users/Administrator/jenkins',
     };
@@ -176,7 +176,7 @@ export class AgentNodes {
         generation: AmazonLinuxGeneration.AMAZON_LINUX_2,
         cpuType: AmazonLinuxCpuType.X86_64,
       }).getImage(stack).imageId.toString(),
-      initScript: 'sudo yum install -y java-1.8.0-openjdk cmake python3 python3-pip && '
+      initScript: 'sudo amazon-linux-extras install java-openjdk11 -y && sudo yum install -y cmake python3 python3-pip && '
           + 'sudo yum groupinstall -y \'Development Tools\' && sudo ln -sfn `which pip3` /usr/bin/pip && '
           + 'pip3 install pipenv && sudo ln -s ~/.local/bin/pipenv /usr/local/bin',
       remoteFs: '/home/ec2-user',
@@ -193,7 +193,7 @@ export class AgentNodes {
         generation: AmazonLinuxGeneration.AMAZON_LINUX_2,
         cpuType: AmazonLinuxCpuType.ARM_64,
       }).getImage(stack).imageId.toString(),
-      initScript: 'sudo yum install -y java-1.8.0-openjdk cmake python3 python3-pip && '
+      initScript: 'sudo amazon-linux-extras install java-openjdk11 -y && sudo yum install -y cmake python3 python3-pip && '
           + 'sudo yum groupinstall -y \'Development Tools\' && sudo ln -sfn `which pip3` /usr/bin/pip && '
           + 'pip3 install pipenv && sudo ln -s ~/.local/bin/pipenv /usr/local/bin',
       remoteFs: '/home/ec2-user',

--- a/lib/compute/jenkins-main-node.ts
+++ b/lib/compute/jenkins-main-node.ts
@@ -7,7 +7,7 @@
  */
 
 import { CfnOutput, Duration, Stack } from 'aws-cdk-lib';
-import { AutoScalingGroup, BlockDeviceVolume, Signals } from 'aws-cdk-lib/aws-autoscaling';
+import { AutoScalingGroup, BlockDeviceVolume, Monitoring, Signals } from 'aws-cdk-lib/aws-autoscaling';
 import { Metric, Unit } from 'aws-cdk-lib/aws-cloudwatch';
 import {
   AmazonLinuxGeneration, CloudFormationInit, InitCommand, InitElement, InitFile, InitPackage,
@@ -144,6 +144,7 @@ export class JenkinsMainNode {
       signals: Signals.waitForAll({
         timeout: Duration.minutes(20),
       }),
+      instanceMonitoring: Monitoring.DETAILED
     });
 
     JenkinsMainNode.createPoliciesForMainNode(stack).map(

--- a/lib/compute/jenkins-main-node.ts
+++ b/lib/compute/jenkins-main-node.ts
@@ -7,14 +7,8 @@
  */
 
 import { CfnOutput, Duration, Stack } from 'aws-cdk-lib';
+import { AutoScalingGroup, BlockDeviceVolume, Signals } from 'aws-cdk-lib/aws-autoscaling';
 import { Metric, Unit } from 'aws-cdk-lib/aws-cloudwatch';
-import { FileSystem, PerformanceMode, ThroughputMode } from 'aws-cdk-lib/aws-efs';
-import {
-  IManagedPolicy, ManagedPolicy, PolicyStatement, Role, ServicePrincipal,
-} from 'aws-cdk-lib/aws-iam';
-import { writeFileSync } from 'fs';
-import { dump } from 'js-yaml';
-import { join } from 'path';
 import {
   AmazonLinuxGeneration, CloudFormationInit, InitCommand, InitElement, InitFile, InitPackage,
   InstanceClass,
@@ -23,7 +17,13 @@ import {
   MachineImage, SecurityGroup,
   SubnetType, Vpc,
 } from 'aws-cdk-lib/aws-ec2';
-import { AutoScalingGroup, BlockDeviceVolume, Signals } from 'aws-cdk-lib/aws-autoscaling';
+import { FileSystem, PerformanceMode, ThroughputMode } from 'aws-cdk-lib/aws-efs';
+import {
+  IManagedPolicy, ManagedPolicy, PolicyStatement, Role, ServicePrincipal,
+} from 'aws-cdk-lib/aws-iam';
+import { writeFileSync } from 'fs';
+import { dump } from 'js-yaml';
+import { join } from 'path';
 import { CloudwatchAgent } from '../constructs/cloudwatch-agent';
 import { AgentNodeConfig, AgentNodeNetworkProps, AgentNodeProps } from './agent-node-config';
 import { EnvConfig } from './env-config';
@@ -224,7 +224,7 @@ export class JenkinsMainNode {
       InitPackage.yum('openssl'),
       InitPackage.yum('mod_ssl'),
       InitPackage.yum('amazon-efs-utils'),
-      InitPackage.yum('java-1.8.0-openjdk'),
+      InitCommand.shellCommand('amazon-linux-extras install java-openjdk11 -y'),
       InitPackage.yum('docker'),
       InitPackage.yum('python3'),
       InitPackage.yum('python3-pip.noarch'),

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "opensearch-ci-stack",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "bin": {
     "ci": "bin/ci-stack.js"
   },

--- a/resources/docker-compose.yml
+++ b/resources/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '3.8'
 services:
   jenkins:
-    image: opensearchstaging/jenkins:2.332.3-lts-jdk8
+    image: opensearchstaging/jenkins:2.387.1-lts-jdk11
     restart: on-failure
     privileged: true
     tty: true

--- a/test/compute/jenkins-main-node.test.ts
+++ b/test/compute/jenkins-main-node.test.ts
@@ -26,8 +26,8 @@ describe('JenkinsMainNode Config Elements', () => {
 
   // THEN
   test('Config elements expected counts', async () => {
-    expect(configElements.filter((e) => e.elementType === 'COMMAND')).toHaveLength(18);
-    expect(configElements.filter((e) => e.elementType === 'PACKAGE')).toHaveLength(10);
+    expect(configElements.filter((e) => e.elementType === 'COMMAND')).toHaveLength(19);
+    expect(configElements.filter((e) => e.elementType === 'PACKAGE')).toHaveLength(9);
     expect(configElements.filter((e) => e.elementType === 'FILE')).toHaveLength(4);
   });
 


### PR DESCRIPTION
### Description
- Upgrade jenkins to 2.387.1
- Use new AMIs that has java 11 as default. Confirmed that all AMIs are public.
- Bump package version to 0.3.0
- Enable detail monitoring for main node
- With recent change in S3 bucket ownership, added change in ownership which resolves below error:
```
 Bucket cannot have ACLs set with ObjectOwnership's BucketOwnerEnforced setting (Service: Amazon S3; Status Code: 400; Error Code: InvalidBucketAclWithObjectOwnership;
```

### Issues Resolved
resolves #261

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
