### PR TITLE
Replace temurin20 with openjdk20 as former is not available on Windows

### DIFF
--- a/packer/scripts/windows/scoop-install-commons.ps1
+++ b/packer/scripts/windows/scoop-install-commons.ps1
@@ -73,7 +73,7 @@ $zlibRegFilePath
 regedit /s $zlibRegFilePath
 
 # Install jdk
-$jdkVersionList = "temurin8-jdk JAVA8_HOME", "temurin11-jdk JAVA11_HOME", "temurin17-jdk JAVA17_HOME", "temurin19-jdk JAVA19_HOME", "temurin20-jdk JAVA20_HOME", "openjdk14 JAVA14_HOME"
+$jdkVersionList = "temurin8-jdk JAVA8_HOME", "temurin11-jdk JAVA11_HOME", "temurin17-jdk JAVA17_HOME", "temurin19-jdk JAVA19_HOME", "openjdk20 JAVA20_HOME", "openjdk14 JAVA14_HOME"
 Foreach ($jdkVersion in $jdkVersionList)
 {
     $jdkVersion


### PR DESCRIPTION
### Description
Replace temurin20 with openjdk20 as former is not available on Windows

### Issues Resolved
https://github.com/opensearch-project/opensearch-build/issues/3425

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
