### PR TITLE
Correct chromium path found in Windows

### DIFF
--- a/packer/scripts/windows/scoop-install-commons.ps1
+++ b/packer/scripts/windows/scoop-install-commons.ps1
@@ -158,7 +158,7 @@ $chromiumName = 'chrome.exe'
 $chromiumDir = 'C:\\Users\\Administrator\\scoop\\apps\\chromium'
 $chromiumFound = (Get-ChildItem -Path $chromiumDir -Filter $chromiumName -Recurse | %{$_.FullName} | select -first 1)
 $chromiumFound
-$chromiumPathFound = $chromiumPathFound.replace("$chromiumName", '')
+$chromiumPathFound = $chromiumFound.replace("$chromiumName", '')
 $chromiumPathFound
 # Add BROWSER_PATH path to User Env Var for cypress test to retrieve chromium.exe path
 [System.Environment]::SetEnvironmentVariable("BROWSER_PATH", "$chromiumPathFound", [System.EnvironmentVariableTarget]::User)


### PR DESCRIPTION
### Description
Correct chromium path found in Windows

### Issues Resolved
https://github.com/opensearch-project/opensearch-build/issues/3425

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
