### PR TITLE
Resolve Windows chromium path and add jdk20 tool on Jenkins

### DIFF
--- a/packer/scripts/windows/scoop-install-commons.ps1
+++ b/packer/scripts/windows/scoop-install-commons.ps1
@@ -162,10 +162,8 @@ $chromiumName = 'chrome.exe'
 $chromiumDir = 'C:\\Users\\Administrator\\scoop\\apps\\chromium'
 $chromiumFound = (Get-ChildItem -Path $chromiumDir -Filter $chromiumName -Recurse | %{$_.FullName} | select -first 1)
 $chromiumFound
-$chromiumPathFound = $chromiumFound.replace("$chromiumName", '')
-$chromiumPathFound
 # Add BROWSER_PATH path to User Env Var for cypress test to retrieve chromium.exe path
-[System.Environment]::SetEnvironmentVariable("BROWSER_PATH", "$chromiumPathFound", [System.EnvironmentVariableTarget]::User)
+[System.Environment]::SetEnvironmentVariable("BROWSER_PATH", "$chromiumFound", [System.EnvironmentVariableTarget]::User)
 
 # Install ruby24
 scoop install ruby24

--- a/resources/baseJenkins.yaml
+++ b/resources/baseJenkins.yaml
@@ -184,6 +184,12 @@ tool:
           installers:
           - adoptOpenJdkInstaller:
               id: "jdk-19.0.1+10"
+    - name: "openjdk-20"
+      properties:
+      - installSource:
+          installers:
+          - adoptOpenJdkInstaller:
+              id: "jdk-20.0.1+9"
   mavenGlobalConfig:
     globalSettingsProvider: "standard"
     settingsProvider: "standard"


### PR DESCRIPTION
### Description
Resolve Windows chromium path and add jdk20 tool on Jenkins

### Issues Resolved
https://github.com/opensearch-project/opensearch-build/issues/1563
https://github.com/opensearch-project/opensearch-build/issues/3434
Closes https://github.com/opensearch-project/opensearch-build/issues/3425

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
