### PR TITLE
[Bug fix] Add logging for workflow runs

### DIFF
--- a/lib/compute/jenkins-main-node.ts
+++ b/lib/compute/jenkins-main-node.ts
@@ -355,6 +355,21 @@ export class JenkinsMainNode {
             },
           },
         },
+        logs: {
+          logs_collected: {
+            files: {
+              collect_list: [
+                {
+                  file_path: '/var/lib/jenkins/logs/custom/workflowRun.log',
+                  log_group_name: 'JenkinsMainNode/workflow.log',
+                  auto_removal: true,
+                  log_stream_name: 'workflow-logs',
+                },
+              ],
+            },
+          },
+          force_flush_interval: 5,
+        },
       }),
       InitCommand.shellCommand('/opt/aws/amazon-cloudwatch-agent/bin/amazon-cloudwatch-agent-ctl -a stop'),
       // eslint-disable-next-line max-len
@@ -386,7 +401,7 @@ export class JenkinsMainNode {
         + ' for i in $varkeys; do newvalue=`echo $var | yq .$i` && myenv=$newvalue i=$i yq -i \'.jenkins.securityRealm.oic.[env(i)]=env(myenv)\' /initial_jenkins.yaml ; done'
         : 'echo No changes made to initial_jenkins.yaml with respect to OIDC'),
 
-      InitCommand.shellCommand('sleep 30'),
+      InitCommand.shellCommand('while [[ "$(curl -s -o /dev/null -w \'\'%{http_code}\'\' localhost:8080/api/json?pretty)" != "200" ]]; do sleep 5; done'),
 
       // Reload configuration via Jenkins.yaml
       InitCommand.shellCommand('cp /initial_jenkins.yaml /var/lib/jenkins/jenkins.yaml &&'

--- a/lib/constructs/cloudwatch-agent.ts
+++ b/lib/constructs/cloudwatch-agent.ts
@@ -9,10 +9,12 @@
 import { InitFile, InitFileOptions } from 'aws-cdk-lib/aws-ec2';
 import { CloudwatchAgentSection } from './cloudwatch/agent-section';
 import { CloudwatchMetricsSection } from './cloudwatch/metrics-section';
+import { CloudwatchLogsSection } from './cloudwatch/logs-section';
 
 export interface CloudwatchAgentConfig {
   agent: CloudwatchAgentSection;
   metrics: CloudwatchMetricsSection;
+  logs: CloudwatchLogsSection;
 }
 
 export class CloudwatchAgent {

--- a/lib/constructs/cloudwatch/logs-section.ts
+++ b/lib/constructs/cloudwatch/logs-section.ts
@@ -17,7 +17,7 @@ interface FileCollectionDefinition {
   // eslint-disable-next-line camelcase
   log_stream_name: string,
   // eslint-disable-next-line camelcase
-  timestamp_format: string,
+  timestamp_format?: string,
 }
 
 interface EditableLogsSection {

--- a/resources/baseJenkins.yaml
+++ b/resources/baseJenkins.yaml
@@ -1,4 +1,10 @@
 jenkins:
+  log:
+    recorders:
+    - loggers:
+      - level: "FINE"
+        name: "org.jenkinsci.plugins.workflow.job.WorkflowRun"
+      name: "workflowRun"
   agentProtocols:
   - "JNLP4-connect"
   - "Ping"
@@ -139,8 +145,6 @@ unclassified:
     charset: "UTF-8"
     useSsl: false
     useTls: false
-  mavenModuleSet:
-    localRepository: "default"
   pluginImpl:
     enableCredentialsFromNode: false
   pollSCM:
@@ -193,3 +197,51 @@ tool:
       name: "DefaultWindows"
     - home: "pwsh"
       name: "DefaultLinux"
+support:
+  automatedBundleConfiguration:
+    componentIds:
+    - "AgentsConfigFile"
+    - "ConfigFileComponent"
+    - "OtherConfigFilesComponent"
+    - "AboutBrowser"
+    - "AboutJenkins"
+    - "AboutUser"
+    - "AdministrativeMonitors"
+    - "AgentProtocols"
+    - "BuildQueue"
+    - "CustomLogs"
+    - "DumpExportTable"
+    - "EnvironmentVariables"
+    - "FileDescriptorLimit"
+    - "GCLogs"
+    - "HeapUsageHistogram"
+    - "ItemsContent"
+    - "AgentsJVMProcessSystemMetricsContents"
+    - "MasterJVMProcessSystemMetricsContents"
+    - "JenkinsLogs"
+    - "LoadStats"
+    - "LoggerManager"
+    - "Metrics"
+    - "NetworkInterfaces"
+    - "NodeMonitors"
+    - "OtherLogs"
+    - "ReverseProxy"
+    - "RootCAs"
+    - "RunningBuilds"
+    - "SlaveCommandStatistics"
+    - "SlaveLaunchLogs"
+    - "SlaveLogs"
+    - "AgentsSystemConfiguration"
+    - "MasterSystemConfiguration"
+    - "SystemProperties"
+    - "TaskLogs"
+    - "ThreadDumps"
+    - "UpdateCenter"
+    - "UserCount"
+    - "SlowRequestComponent"
+    - "HighLoadComponent"
+    - "DeadlockRequestComponent"
+    - "PipelineTimings"
+    - "PipelineThreadDump"
+    enabled: true
+    period: 1

--- a/test/compute/env-config.test.ts
+++ b/test/compute/env-config.test.ts
@@ -8,8 +8,8 @@
 
 import { readFileSync, writeFileSync } from 'fs';
 import { dump, load } from 'js-yaml';
-import { JenkinsMainNode } from '../../lib/compute/jenkins-main-node';
 import { EnvConfig } from '../../lib/compute/env-config';
+import { JenkinsMainNode } from '../../lib/compute/jenkins-main-node';
 
 describe('Env Config', () => {
   // WHEN
@@ -35,5 +35,22 @@ describe('Env Config', () => {
     };
     const addedEnvConfig = yml.jenkins.globalNodeProperties;
     expect(addedEnvConfig).toEqual([envConfig]);
+  });
+
+  test('Verify logger', async () => {
+    const workflowLogger = {
+      recorders: [
+        {
+          name: 'org.jenkinsci.plugins.workflow.job.WorkflowRun',
+          loggers: [{
+            level: 'FINE',
+            name: 'org.jenkinsci.plugins.workflow.job.WorkflowRun',
+          },
+          ],
+        },
+      ],
+    };
+    const getlog = yml.jenkins.log;
+    expect(getlog).toEqual(workflowLogger);
   });
 });

--- a/test/compute/env-config.test.ts
+++ b/test/compute/env-config.test.ts
@@ -41,7 +41,7 @@ describe('Env Config', () => {
     const workflowLogger = {
       recorders: [
         {
-          name: 'org.jenkinsci.plugins.workflow.job.WorkflowRun',
+          name: 'workflowRun',
           loggers: [{
             level: 'FINE',
             name: 'org.jenkinsci.plugins.workflow.job.WorkflowRun',

--- a/test/data/test_env.yaml
+++ b/test/data/test_env.yaml
@@ -4,7 +4,7 @@ jenkins:
       - loggers:
           - level: FINE
             name: org.jenkinsci.plugins.workflow.job.WorkflowRun
-        name: org.jenkinsci.plugins.workflow.job.WorkflowRun
+        name: workflowRun
   agentProtocols:
     - JNLP4-connect
     - Ping

--- a/test/data/test_env.yaml
+++ b/test/data/test_env.yaml
@@ -1,4 +1,10 @@
 jenkins:
+  log:
+    recorders:
+      - loggers:
+          - level: FINE
+            name: org.jenkinsci.plugins.workflow.job.WorkflowRun
+        name: org.jenkinsci.plugins.workflow.job.WorkflowRun
   agentProtocols:
     - JNLP4-connect
     - Ping
@@ -151,8 +157,6 @@ unclassified:
     charset: UTF-8
     useSsl: false
     useTls: false
-  mavenModuleSet:
-    localRepository: default
   pluginImpl:
     enableCredentialsFromNode: false
   pollSCM:
@@ -205,3 +209,51 @@ tool:
         name: DefaultWindows
       - home: pwsh
         name: DefaultLinux
+support:
+  automatedBundleConfiguration:
+    componentIds:
+      - AgentsConfigFile
+      - ConfigFileComponent
+      - OtherConfigFilesComponent
+      - AboutBrowser
+      - AboutJenkins
+      - AboutUser
+      - AdministrativeMonitors
+      - AgentProtocols
+      - BuildQueue
+      - CustomLogs
+      - DumpExportTable
+      - EnvironmentVariables
+      - FileDescriptorLimit
+      - GCLogs
+      - HeapUsageHistogram
+      - ItemsContent
+      - AgentsJVMProcessSystemMetricsContents
+      - MasterJVMProcessSystemMetricsContents
+      - JenkinsLogs
+      - LoadStats
+      - LoggerManager
+      - Metrics
+      - NetworkInterfaces
+      - NodeMonitors
+      - OtherLogs
+      - ReverseProxy
+      - RootCAs
+      - RunningBuilds
+      - SlaveCommandStatistics
+      - SlaveLaunchLogs
+      - SlaveLogs
+      - AgentsSystemConfiguration
+      - MasterSystemConfiguration
+      - SystemProperties
+      - TaskLogs
+      - ThreadDumps
+      - UpdateCenter
+      - UserCount
+      - SlowRequestComponent
+      - HighLoadComponent
+      - DeadlockRequestComponent
+      - PipelineTimings
+      - PipelineThreadDump
+    enabled: true
+    period: 1


### PR DESCRIPTION
### Description
The jenkins upgrade broke the logging for workflow runs that is required for monitoring. This PR adds the workflow run custom loggers and accordingly cloudwatch log group as well as logstream.
Will create a new logging file under `/var/lib/jenkins/logs/custom` called as `workflowRun.log`
Also creates cloudwatch log group called `JenkinsMainNode/workflow.log` with log stream named `workflow-logs`

### Issues Resolved
resolves https://github.com/opensearch-project/opensearch-ci/issues/290

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
