### PR TITLE
Reduce # of executors for benchmark agent to 2

### DIFF
--- a/lib/compute/agent-nodes.ts
+++ b/lib/compute/agent-nodes.ts
@@ -85,7 +85,7 @@ export class AgentNodes {
       remoteUser: 'ec2-user',
       maxTotalUses: -1,
       minimumNumberOfSpareInstances: 1,
-      numExecutors: 4,
+      numExecutors: 2,
       amiId: 'ami-0174f9a449737d559',
       initScript: 'sudo yum clean all && sudo rm -rf /var/cache/yum /var/lib/yum/history && sudo yum repolist &&'
           + ' sudo yum update --skip-broken --exclude=openssh* --exclude=docker* --exclude=gh* -y && docker ps',


### PR DESCRIPTION
### Description
Reduce # of executors for benchmark agent to 2. There has been situation when there were 4 instances of `nyc_taxis` workload was running on one node resulting in `not enough disk space` error as each instance tries to download ~75gb of data. 
This also spikes the disk I/O resulting in degraded performance of benchmarking process. 
Running with 2 executors has shown significant improvement.  

### Issues Resolved
_List any issues this PR will resolve, e.g. Closes [...]._ 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
