### PR TITLE
[Python 3.9 Upgrade] Lock Windows Python to 3.9.7 and cmake to 3.21.3 (Part 2)

### DIFF
--- a/packer/scripts/windows/scoop-install-commons.ps1
+++ b/packer/scripts/windows/scoop-install-commons.ps1
@@ -94,7 +94,8 @@ $JAVA_HOME_TEMP
 java -version
 
 # Install python
-scoop install python39
+# Lock to 3.9.7
+scoop install https://raw.githubusercontent.com/ScoopInstaller/Versions/89abc5b8f72ca84d013d30770fef7f61755b79e8/bucket/python39.json
 python --version
 # Reg PEP
 $versionInfo = (scoop info python39 | out-string -stream | Select-String 'Version.*:')
@@ -183,7 +184,8 @@ scoop install gh
 gh version
 
 # Install dev tools
-scoop install cmake
+# Lock to 3.21.3
+scoop install https://raw.githubusercontent.com/ScoopInstaller/Main/67ef407eec0cb7e6a9c9f72117a5b3e7a47e4e56/bucket/cmake.json
 cmake --version
 
 # Install zip


### PR DESCRIPTION
### Description
 [Python 3.9 Upgrade] Lock Windows Python to 3.9.7 and cmake to 3.21.3 (Part 2) #313 

### Issues Resolved
https://github.com/opensearch-project/opensearch-build/issues/3351

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
