### PR TITLE
[Python 3.9 Upgrade] Restore python39 back to latest version due to old json not supported on scoop for 3.9.7 anymore

### DIFF
--- a/packer/scripts/windows/scoop-install-commons.ps1
+++ b/packer/scripts/windows/scoop-install-commons.ps1
@@ -94,8 +94,7 @@ $JAVA_HOME_TEMP
 java -version
 
 # Install python
-# Lock to 3.9.7
-scoop install https://raw.githubusercontent.com/ScoopInstaller/Versions/89abc5b8f72ca84d013d30770fef7f61755b79e8/bucket/python39.json
+scoop install python39
 python --version
 # Reg PEP
 $versionInfo = (scoop info python39 | out-string -stream | Select-String 'Version.*:')


### PR DESCRIPTION


### Description
[Python 3.9 Upgrade] Restore python39 back to latest version due to old json not supported on scoop for 3.9.7 anymore

### Issues Resolved
https://github.com/opensearch-project/opensearch-build/issues/3351

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
