### PR TITLE
[Python 3.9 Upgrade] [NodeJS Upgrade] Switch the internal ami name from al2 to al2023

### DIFF
--- a/packer/jenkins-agent-al2023-arm64.json
+++ b/packer/jenkins-agent-al2023-arm64.json
@@ -27,7 +27,7 @@
           "virtualization-type":"hvm",
           "architecture":"arm64",
           "name": "al2023-ami-20*",
-          "block-device-mapping.volume-type":"gp2",
+          "block-device-mapping.volume-type":"gp3",
           "root-device-type":"ebs"
         },
         "owners": [

--- a/packer/jenkins-agent-al2023-arm64.json
+++ b/packer/jenkins-agent-al2023-arm64.json
@@ -26,7 +26,7 @@
         "filters": {
           "virtualization-type":"hvm",
           "architecture":"arm64",
-          "name": "amzn2-ami-kernel-5.10-hvm-*",
+          "name": "al2023-ami-20*",
           "block-device-mapping.volume-type":"gp2",
           "root-device-type":"ebs"
         },

--- a/packer/jenkins-agent-al2023-x64.json
+++ b/packer/jenkins-agent-al2023-x64.json
@@ -26,7 +26,7 @@
         "filters": {
           "virtualization-type":"hvm",
           "architecture":"x86_64",
-          "name": "amzn2-ami-kernel-5.10-hvm-*",
+	  "name": "al2023-ami-20*",
           "block-device-mapping.volume-type":"gp2",
           "root-device-type":"ebs"
         },

--- a/packer/jenkins-agent-al2023-x64.json
+++ b/packer/jenkins-agent-al2023-x64.json
@@ -27,7 +27,7 @@
           "virtualization-type":"hvm",
           "architecture":"x86_64",
 	  "name": "al2023-ami-20*",
-          "block-device-mapping.volume-type":"gp2",
+          "block-device-mapping.volume-type":"gp3",
           "root-device-type":"ebs"
         },
         "owners": [


### PR DESCRIPTION
### Description
[Python 3.9 Upgrade] [NodeJS Upgrade] Switch the internal ami name from al2 to al2023

### Issues Resolved
https://github.com/opensearch-project/opensearch-build/issues/3351
https://github.com/opensearch-project/opensearch-build/issues/1563

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
