### PR TITLE
[Python 3.9 Upgrade] Update macos agent to Python 3.9 export and add M58xlarge gradle check runner

### DIFF
--- a/lib/ci-stack.ts
+++ b/lib/ci-stack.ts
@@ -155,7 +155,8 @@ export class CIStack extends Stack {
 
       this.agentNodes = [
         agentNode.AL2_X64, agentNode.AL2_X64_DOCKER_HOST, agentNode.AL2023_X64_DOCKER_HOST_PERF_TEST, agentNode.AL2023_X64_DOCKER_HOST_BENCHMARK_TEST,
-        agentNode.AL2_ARM64, agentNode.AL2_ARM64_DOCKER_HOST, agentNode.UBUNTU2004_X64_GRADLE_CHECK, agentNode.UBUNTU2004_X64_DOCKER_BUILDER,
+        agentNode.AL2_ARM64, agentNode.AL2_ARM64_DOCKER_HOST,
+        agentNode.UBUNTU2004_X64_GRADLE_CHECK, agentNode.UBUNTU2004_X64_GRADLE_CHECK_NEW_SPECS, agentNode.UBUNTU2004_X64_DOCKER_BUILDER,
         agentNode.MACOS12_X64_MULTI_HOST, agentNode.WINDOWS2019_X64, agentNode.WINDOWS2019_X64_GRADLE_CHECK,
       ];
     } else {

--- a/lib/compute/agent-nodes.ts
+++ b/lib/compute/agent-nodes.ts
@@ -26,6 +26,8 @@ export class AgentNodes {
 
   readonly UBUNTU2004_X64_GRADLE_CHECK: AgentNodeProps;
 
+  readonly UBUNTU2004_X64_GRADLE_CHECK_NEW_SPECS: AgentNodeProps;
+
   readonly UBUNTU2004_X64_DOCKER_BUILDER: AgentNodeProps;
 
   readonly MACOS12_X64_MULTI_HOST: AgentNodeProps;
@@ -124,6 +126,19 @@ export class AgentNodes {
       remoteUser: 'ubuntu',
       maxTotalUses: 1,
       minimumNumberOfSpareInstances: 1,
+      numExecutors: 1,
+      amiId: 'ami-0776ef32c1c17729d',
+      initScript: 'sudo apt-mark hold docker docker.io openssh-server gh grub-efi* shim-signed && docker ps &&'
+      + ' sudo apt-get update -y && (sudo killall -9 apt-get apt 2>&1 || echo) && sudo env "DEBIAN_FRONTEND=noninteractive" apt-get upgrade -y',
+      remoteFs: '/var/jenkins',
+    };
+    this.UBUNTU2004_X64_GRADLE_CHECK_NEW_SPECS = {
+      agentType: 'unix',
+      workerLabelString: 'Jenkins-Agent-Ubuntu2004-X64-M58xlarge-Single-Host',
+      instanceType: 'M58xlarge',
+      remoteUser: 'ubuntu',
+      maxTotalUses: -1,
+      minimumNumberOfSpareInstances: 0,
       numExecutors: 1,
       amiId: 'ami-0776ef32c1c17729d',
       initScript: 'sudo apt-mark hold docker docker.io openssh-server gh grub-efi* shim-signed && docker ps &&'

--- a/packer/files/macos/bashrc
+++ b/packer/files/macos/bashrc
@@ -1,5 +1,5 @@
 export PATH=/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin:$PATH
 export PATH=/opt/local/bin:$PATH
-export PATH=/Users/ec2-user/Library/Python/3.7/bin:/opt/local/Library/Frameworks/Python.framework/Versions/3.7/bin:$PATH
+export PATH=/Users/ec2-user/Library/Python/3.9/bin:/opt/local/Library/Frameworks/Python.framework/Versions/3.9/bin:$PATH
 export PATH=/usr/local/opt/grep/libexec/gnubin:$PATH
 export PATH=/usr/local/opt/gnu-sed/libexec/gnubin:$PATH


### PR DESCRIPTION
### Description
Update macos agent to Python 3.9 export and add M58xlarge gradle check runner

### Issues Resolved
https://github.com/opensearch-project/opensearch-build/issues/3351
https://github.com/opensearch-project/opensearch-ci/issues/321

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
