### PR TITLE
Update cmake to 3.23.3 for k-NN in 2.9.0 in AMIs

### DIFF
--- a/packer/scripts/macos/macos-agentsetup.sh
+++ b/packer/scripts/macos/macos-agentsetup.sh
@@ -33,5 +33,5 @@ python3 get-pip.py
 export PATH=/Users/ec2-user/Library/Python/3.9/bin:/opt/local/Library/Frameworks/Python.framework/Versions/3.9/bin:$PATH
 pip install pipenv==2023.6.12
 pip install awscli==1.22.12
-pip install cmake==3.21.3
+pip install cmake==3.23.3
 

--- a/packer/scripts/windows/scoop-install-commons.ps1
+++ b/packer/scripts/windows/scoop-install-commons.ps1
@@ -183,8 +183,8 @@ scoop install gh
 gh version
 
 # Install dev tools
-# Lock to 3.21.3
-scoop install https://raw.githubusercontent.com/ScoopInstaller/Main/67ef407eec0cb7e6a9c9f72117a5b3e7a47e4e56/bucket/cmake.json
+# Lock to 3.23.3
+scoop install https://raw.githubusercontent.com/ScoopInstaller/Main/56eed69c3bf04110e306f77ad45cfc8c1c5bb9bc/bucket/cmake.json
 cmake --version
 
 # Install zip


### PR DESCRIPTION
### Description
Update cmake to 3.23.3 for k-NN in 2.9.0 in AMIs

### Issues Resolved
https://github.com/opensearch-project/opensearch-build/issues/3706

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
