### PR TITLE
Update the new macos/windows ami ids with cmake upgrade 3.23.3 in #324

### DIFF
--- a/lib/compute/agent-nodes.ts
+++ b/lib/compute/agent-nodes.ts
@@ -166,7 +166,7 @@ export class AgentNodes {
       maxTotalUses: -1,
       minimumNumberOfSpareInstances: 1,
       numExecutors: 6,
-      amiId: 'ami-0d2467b182fa190a9',
+      amiId: 'ami-07cca274b629d3724',
       initScript: 'echo',
       remoteFs: '/var/jenkins',
     };
@@ -178,7 +178,7 @@ export class AgentNodes {
       maxTotalUses: -1,
       minimumNumberOfSpareInstances: 2,
       numExecutors: 1,
-      amiId: 'ami-0d6fa7800e282577d',
+      amiId: 'ami-04c2718dc4aef8420',
       initScript: 'echo',
       remoteFs: 'C:/Users/Administrator/jenkins',
     };
@@ -190,7 +190,7 @@ export class AgentNodes {
       maxTotalUses: 1,
       minimumNumberOfSpareInstances: 1,
       numExecutors: 1,
-      amiId: 'ami-06d954b7346f541c2',
+      amiId: 'ami-01a6fce4b2e29dd6a',
       initScript: 'echo',
       remoteFs: 'C:/Users/Administrator/jenkins',
     };


### PR DESCRIPTION
### Description
Update the new macos/windows ami ids with cmake upgrade 3.23.3 in #324

### Issues Resolved
https://github.com/opensearch-project/opensearch-build/issues/3706

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
