### PR TITLE
Enable IMDSv2 on jenkins main node

### DIFF
--- a/test/compute/jenkins-main-node.test.ts
+++ b/test/compute/jenkins-main-node.test.ts
@@ -26,7 +26,7 @@ describe('JenkinsMainNode Config Elements', () => {
 
   // THEN
   test('Config elements expected counts', async () => {
-    expect(configElements.filter((e) => e.elementType === 'COMMAND')).toHaveLength(19);
+    expect(configElements.filter((e) => e.elementType === 'COMMAND')).toHaveLength(20);
     expect(configElements.filter((e) => e.elementType === 'PACKAGE')).toHaveLength(9);
     expect(configElements.filter((e) => e.elementType === 'FILE')).toHaveLength(4);
   });


### PR DESCRIPTION
### Description
We had already enabled IMDSv2 on all agent nodes before in order to make secure calls to instance metadata. See https://github.com/opensearch-project/opensearch-ci/pull/273.
This change enables the same on main node. 

### Issues Resolved
_List any issues this PR will resolve, e.g. Closes [...]._ 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
