### PR TITLE
[NodeJS18 Upgrade] Remove old AL2 Docker Host and Tweak Windows Startup Scripts

### DIFF
--- a/lib/ci-stack.ts
+++ b/lib/ci-stack.ts
@@ -161,7 +161,6 @@ export class CIStack extends Stack {
         agentNode.AL2_ARM64_DOCKER_HOST,
         agentNode.AL2023_ARM64_DOCKER_HOST,
         agentNode.AL2023_X64_BENCHMARK_TEST,
-        agentNode.AL2023_X64_BENCHMARK_TEST_NEW_SPEC,
         agentNode.UBUNTU2004_X64_GRADLE_CHECK,
         agentNode.UBUNTU2004_X64_DOCKER_BUILDER,
         agentNode.MACOS12_X64_MULTI_HOST,

--- a/lib/compute/agent-nodes.ts
+++ b/lib/compute/agent-nodes.ts
@@ -208,8 +208,10 @@ export class AgentNodes {
       numExecutors: 4,
       amiId: 'ami-043fc8c0db1626fd2',
       initScript: 'echo %USERNAME% && dockerd --register-service && net start docker && echo started docker deamon && docker ps && '
-          + 'echo initializing docker images now waiting for 5min && docker run --rm -it  --name docker-windows-test '
-          + '-d public.ecr.aws/opensearchstaging/ci-runner:ci-runner-windows2019-servercore-opensearch-build-v1 bash.exe -c "whoami && exit"',
+          + 'echo initializing docker images now waiting for 5min && git clone https://github.com/opensearch-project/opensearch-build.git && '
+          + 'bash.exe -c "docker run --rm -it  --name docker-windows-test -d `opensearch-build/docker/ci/get-ci-images.sh '
+          + '-p windows2019-servercore -u opensearch -t build | head -1` bash.exe && sleep 5" && docker exec -it docker-windows-test whoami && '
+          + 'docker ps && docker stop docker-windows-test && docker ps && rm -rf opensearch-build',
       remoteFs: 'C:/Users/Administrator/jenkins',
     };
     this.WINDOWS2019_X64_DOCKER_BUILDER = {
@@ -223,8 +225,10 @@ export class AgentNodes {
       numExecutors: 1,
       amiId: 'ami-043fc8c0db1626fd2',
       initScript: 'echo %USERNAME% && dockerd --register-service && net start docker && echo started docker deamon && docker ps && '
-          + 'echo initializing docker images now waiting for 5min && docker run --rm -it  --name docker-windows-test '
-          + '-d public.ecr.aws/opensearchstaging/ci-runner:ci-runner-windows2019-servercore-opensearch-build-v1 bash.exe -c "whoami && exit"',
+          + 'echo initializing docker images now waiting for 5min && git clone https://github.com/opensearch-project/opensearch-build.git && '
+          + 'bash.exe -c "docker run --rm -it  --name docker-windows-test -d `opensearch-build/docker/ci/get-ci-images.sh '
+          + '-p windows2019-servercore -u opensearch -t build | head -1` bash.exe && sleep 5" && docker exec -it docker-windows-test whoami && '
+          + 'docker ps && docker stop docker-windows-test && docker ps && rm -rf opensearch-build',
       remoteFs: 'C:/Users/Administrator/jenkins',
     };
     this.WINDOWS2019_X64_GRADLE_CHECK = {

--- a/lib/compute/agent-nodes.ts
+++ b/lib/compute/agent-nodes.ts
@@ -26,8 +26,6 @@ export class AgentNodes {
 
   readonly AL2023_X64_BENCHMARK_TEST: AgentNodeProps;
 
-  readonly AL2023_X64_BENCHMARK_TEST_NEW_SPEC: AgentNodeProps;
-
   readonly UBUNTU2004_X64_GRADLE_CHECK: AgentNodeProps;
 
   readonly UBUNTU2004_X64_DOCKER_BUILDER: AgentNodeProps;
@@ -145,20 +143,6 @@ export class AgentNodes {
           + ' sudo dnf update --skip-broken --exclude=openssh* --exclude=docker* --exclude=gh* --exclude=python* -y && docker ps',
       remoteFs: '/var/jenkins',
     };
-    this.AL2023_X64_BENCHMARK_TEST_NEW_SPEC = {
-      agentType: 'unix',
-      customDeviceMapping: '/dev/xvda=:600:true:::encrypted',
-      workerLabelString: 'Jenkins-Agent-AL2023-X64-C54xlarge-Benchmark-Test-New-Spec',
-      instanceType: 'C54xlarge',
-      remoteUser: 'ec2-user',
-      maxTotalUses: -1,
-      minimumNumberOfSpareInstances: 1,
-      numExecutors: 4,
-      amiId: 'ami-01dfbac890366ceda',
-      initScript: 'sudo dnf clean all && sudo rm -rf /var/cache/dnf && sudo dnf repolist &&'
-          + ' sudo dnf update --skip-broken --exclude=openssh* --exclude=docker* --exclude=gh* --exclude=python* -y && docker ps',
-      remoteFs: '/var/jenkins',
-    };
     this.UBUNTU2004_X64_GRADLE_CHECK = {
       agentType: 'unix',
       customDeviceMapping: '/dev/sda1=:300:true:::encrypted',
@@ -223,7 +207,9 @@ export class AgentNodes {
       minimumNumberOfSpareInstances: 2,
       numExecutors: 4,
       amiId: 'ami-043fc8c0db1626fd2',
-      initScript: 'echo %USERNAME% && dockerd --register-service && net start docker && echo started docker deamon && docker ps',
+      initScript: 'echo %USERNAME% && dockerd --register-service && net start docker && echo started docker deamon && docker ps && '
+          + 'echo initializing docker images now waiting for 5min && docker run --rm -it  --name docker-windows-test '
+          + '-d public.ecr.aws/opensearchstaging/ci-runner:ci-runner-windows2019-servercore-opensearch-build-v1 bash.exe -c "whoami && exit"',
       remoteFs: 'C:/Users/Administrator/jenkins',
     };
     this.WINDOWS2019_X64_DOCKER_BUILDER = {
@@ -236,7 +222,9 @@ export class AgentNodes {
       minimumNumberOfSpareInstances: 1,
       numExecutors: 1,
       amiId: 'ami-043fc8c0db1626fd2',
-      initScript: 'echo %USERNAME% && dockerd --register-service && net start docker && echo started docker deamon && docker ps',
+      initScript: 'echo %USERNAME% && dockerd --register-service && net start docker && echo started docker deamon && docker ps && '
+          + 'echo initializing docker images now waiting for 5min && docker run --rm -it  --name docker-windows-test '
+          + '-d public.ecr.aws/opensearchstaging/ci-runner:ci-runner-windows2019-servercore-opensearch-build-v1 bash.exe -c "whoami && exit"',
       remoteFs: 'C:/Users/Administrator/jenkins',
     };
     this.WINDOWS2019_X64_GRADLE_CHECK = {

--- a/packer/scripts/windows/scoop-install-commons-docker-support.ps1
+++ b/packer/scripts/windows/scoop-install-commons-docker-support.ps1
@@ -86,6 +86,12 @@ rm -v "$pigzPath\\*.zip"
 $machineenv = [System.Environment]::GetEnvironmentVariable("Path", [System.EnvironmentVariableTarget]::Machine)
 [System.Environment]::SetEnvironmentVariable("PATH", $machineenv + ";$pigzPath", [System.EnvironmentVariableTarget]::Machine)
 
+# Install gcrane to handle dynamic ci image retrieval, use pigz path
+curl.exe -SL "https://github.com/google/go-containerregistry/releases/download/v0.15.2/go-containerregistry_Windows_x86_64.tar.gz" -o "$pigzPath\\gcrane.tar.gz"
+tar -xzvf "$pigzPath\\gcrane.tar.gz" -C "$pigzPath" "crane.exe"
+rm -v "$pigzPath\\gcrane.tar.gz"
+dir $pigzPath
+
 # Setup Docker
 echo "Enable Hyper-V"
 Enable-WindowsOptionalFeature -Online -FeatureName "Microsoft-Hyper-V" -All -NoRestart


### PR DESCRIPTION
### Description
[NodeJS18 Upgrade] Remove old AL2 Docker Host and Tweak Windows Startup Scripts

### Issues Resolved
https://github.com/opensearch-project/opensearch-build/issues/1563
https://github.com/opensearch-project/opensearch-build/issues/3743

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
