### PR TITLE
[Windows Container] Remove interactive shell so Windows AMI can start properly

### DIFF
--- a/lib/compute/agent-nodes.ts
+++ b/lib/compute/agent-nodes.ts
@@ -210,7 +210,7 @@ export class AgentNodes {
       initScript: 'echo %USERNAME% && dockerd --register-service && net start docker && echo started docker deamon && docker ps && '
           + 'echo initializing docker images now waiting for 5min && git clone https://github.com/opensearch-project/opensearch-build.git && '
           + 'bash.exe -c "docker run --rm -it  --name docker-windows-test -d `opensearch-build/docker/ci/get-ci-images.sh '
-          + '-p windows2019-servercore -u opensearch -t build | head -1` bash.exe && sleep 5" && docker exec -it docker-windows-test whoami && '
+          + '-p windows2019-servercore -u opensearch -t build | head -1` bash.exe && sleep 5" && docker exec docker-windows-test whoami && '
           + 'docker ps && docker stop docker-windows-test && docker ps && rm -rf opensearch-build',
       remoteFs: 'C:/Users/Administrator/jenkins',
     };
@@ -227,7 +227,7 @@ export class AgentNodes {
       initScript: 'echo %USERNAME% && dockerd --register-service && net start docker && echo started docker deamon && docker ps && '
           + 'echo initializing docker images now waiting for 5min && git clone https://github.com/opensearch-project/opensearch-build.git && '
           + 'bash.exe -c "docker run --rm -it  --name docker-windows-test -d `opensearch-build/docker/ci/get-ci-images.sh '
-          + '-p windows2019-servercore -u opensearch -t build | head -1` bash.exe && sleep 5" && docker exec -it docker-windows-test whoami && '
+          + '-p windows2019-servercore -u opensearch -t build | head -1` bash.exe && sleep 5" && docker exec docker-windows-test whoami && '
           + 'docker ps && docker stop docker-windows-test && docker ps && rm -rf opensearch-build',
       remoteFs: 'C:/Users/Administrator/jenkins',
     };


### PR DESCRIPTION
### Description
[Windows Container] Remove interactive shell so Windows AMI can start properly

### Issues Resolved
https://github.com/opensearch-project/opensearch-ci/issues/281
https://github.com/opensearch-project/opensearch-build/issues/3743

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
