### PR TITLE
Replace c54xlarge instance with c59xlarge on Jenkins Main Node

### DIFF
--- a/lib/compute/jenkins-main-node.ts
+++ b/lib/compute/jenkins-main-node.ts
@@ -112,7 +112,7 @@ export class JenkinsMainNode {
       this.EFS_ID = efs.fileSystemId;
     }
     this.mainNodeAsg = new AutoScalingGroup(stack, 'MainNodeAsg', {
-      instanceType: InstanceType.of(InstanceClass.C5, InstanceSize.XLARGE4),
+      instanceType: InstanceType.of(InstanceClass.C5, InstanceSize.XLARGE9),
       machineImage: MachineImage.latestAmazonLinux({
         generation: AmazonLinuxGeneration.AMAZON_LINUX_2,
       }),

--- a/resources/docker-compose.yml
+++ b/resources/docker-compose.yml
@@ -11,18 +11,18 @@ services:
       - 50000:50000
     container_name: jenkins
     environment:
-      - JENKINS_JAVA_OPTS="-Xmx18g"
+      - JENKINS_JAVA_OPTS="-Xmx60g -Xss4m"
       - CASC_RELOAD_TOKEN=reloadPasswordHere
     volumes:
       - /var/lib/jenkins:/var/jenkins_home
     deploy:
       resources:
         limits:
-          cpus: '12'
-          memory: '20g'
+          cpus: '32'
+          memory: '64g'
         reservations:
-          cpus: '12'
-          memory: '20g'
+          cpus: '32'
+          memory: '64g'
     logging:
       driver: awslogs
       options:

--- a/test/ci-stack.test.ts
+++ b/test/ci-stack.test.ts
@@ -138,7 +138,7 @@ test('MainNode', () => {
 
   // THEN
   Template.fromStack(stack).hasResourceProperties('AWS::AutoScaling::LaunchConfiguration', {
-    InstanceType: 'c5.4xlarge',
+    InstanceType: 'c5.9xlarge',
     SecurityGroups: [
       {
         'Fn::GetAtt': [


### PR DESCRIPTION
### Description
Replace c54xlarge instance with c59xlarge on Jenkins Main Node

### Issues Resolved
https://github.com/opensearch-project/opensearch-ci/issues/346

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
