### PR TITLE
Remove quotes around JENKINS_JAVA_OPTS to allow multiple entries

### DIFF
--- a/resources/docker-compose.yml
+++ b/resources/docker-compose.yml
@@ -11,7 +11,7 @@ services:
       - 50000:50000
     container_name: jenkins
     environment:
-      - JENKINS_JAVA_OPTS="-Xmx60g -Xss4m"
+      - JENKINS_JAVA_OPTS=-Xmx60g -Xss4m
       - CASC_RELOAD_TOKEN=reloadPasswordHere
     volumes:
       - /var/lib/jenkins:/var/jenkins_home


### PR DESCRIPTION
### Description
Remove quotes around JENKINS_JAVA_OPTS to allow multiple entries

### Issues Resolved
Closes https://github.com/opensearch-project/opensearch-ci/issues/346

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
