### PR TITLE
Switch Windows gradle check runner from C524large to M58xlarge matching LINUX

### DIFF
--- a/packer/jenkins-agent-win2019-x64-gradle-check.json
+++ b/packer/jenkins-agent-win2019-x64-gradle-check.json
@@ -17,7 +17,7 @@
       "encrypt_boot":"false",
       "region":"{{user `build-region`}}",
       "ami_regions":"{{user `aws_ami_region`}}",
-      "instance_type":"c5.24xlarge",
+      "instance_type":"m5.8xlarge",
       "ami_name":"{{user `name-base`}}-{{user `build-time`}}",
       "vpc_id":"{{user `build-vpc`}}",
       "subnet_id":"{{user `build-subnet`}}",
@@ -68,7 +68,7 @@
     {
       "type":"powershell",
       "inline": [
-        "C:\\Users\\Administrator\\jenkins\\winrm_max_memory.ps1 190"
+        "C:\\Users\\Administrator\\jenkins\\winrm_max_memory.ps1 120"
       ]
     },
     {


### PR DESCRIPTION


### Description
Switch Windows gradle check runner from C524large to M58xlarge matching LINUX

### Issues Resolved
https://github.com/opensearch-project/opensearch-build/issues/3816

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
