### PR TITLE
Remove old Windows runner and replace Windows Gradle Check Runner AMI ID with M58xlarge

### DIFF
--- a/lib/ci-stack.ts
+++ b/lib/ci-stack.ts
@@ -164,7 +164,6 @@ export class CIStack extends Stack {
         agentNode.UBUNTU2004_X64_GRADLE_CHECK,
         agentNode.UBUNTU2004_X64_DOCKER_BUILDER,
         agentNode.MACOS12_X64_MULTI_HOST,
-        agentNode.WINDOWS2019_X64,
         agentNode.WINDOWS2019_X64_DOCKER_HOST,
         agentNode.WINDOWS2019_X64_DOCKER_BUILDER,
         agentNode.WINDOWS2019_X64_GRADLE_CHECK,

--- a/lib/compute/agent-nodes.ts
+++ b/lib/compute/agent-nodes.ts
@@ -32,8 +32,6 @@ export class AgentNodes {
 
   readonly MACOS12_X64_MULTI_HOST: AgentNodeProps;
 
-  readonly WINDOWS2019_X64: AgentNodeProps;
-
   readonly WINDOWS2019_X64_DOCKER_HOST: AgentNodeProps;
 
   readonly WINDOWS2019_X64_DOCKER_BUILDER: AgentNodeProps;
@@ -184,19 +182,6 @@ export class AgentNodes {
       initScript: 'echo',
       remoteFs: '/var/jenkins',
     };
-    this.WINDOWS2019_X64 = {
-      agentType: 'windows',
-      customDeviceMapping: '/dev/sda1=:300:true:::encrypted',
-      workerLabelString: 'Jenkins-Agent-Windows2019-X64-C54xlarge-Single-Host',
-      instanceType: 'C54xlarge',
-      remoteUser: 'Administrator',
-      maxTotalUses: -1,
-      minimumNumberOfSpareInstances: 1,
-      numExecutors: 1,
-      amiId: 'ami-03b2c75c26036be68',
-      initScript: 'echo',
-      remoteFs: 'C:/Users/Administrator/jenkins',
-    };
     this.WINDOWS2019_X64_DOCKER_HOST = {
       agentType: 'windows',
       customDeviceMapping: '/dev/sda1=:600:true:::encrypted',
@@ -234,13 +219,13 @@ export class AgentNodes {
     this.WINDOWS2019_X64_GRADLE_CHECK = {
       agentType: 'windows',
       customDeviceMapping: '/dev/sda1=:300:true:::encrypted',
-      workerLabelString: 'Jenkins-Agent-Windows2019-X64-C524xlarge-Single-Host',
-      instanceType: 'C524xlarge',
+      workerLabelString: 'Jenkins-Agent-Windows2019-X64-M58xlarge-Single-Host',
+      instanceType: 'M58xlarge',
       remoteUser: 'Administrator',
       maxTotalUses: 1,
       minimumNumberOfSpareInstances: 1,
       numExecutors: 1,
-      amiId: 'ami-040572cc564dd011c',
+      amiId: 'ami-0a00aabd70b0757f9',
       initScript: 'echo',
       remoteFs: 'C:/Users/Administrator/jenkins',
     };


### PR DESCRIPTION


### Description
Remove old Windows runner and replace Windows Gradle Check Runner AMI ID with M58xlarge

### Issues Resolved
https://github.com/opensearch-project/opensearch-build/issues/3816

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
