### PR TITLE
Make sure windows gradle check runner is supporting docker

### DIFF
--- a/packer/jenkins-agent-win2019-x64-gradle-check.json
+++ b/packer/jenkins-agent-win2019-x64-gradle-check.json
@@ -77,8 +77,7 @@
         "scripts/windows/smb-setup-2019-plus.ps1",
         "scripts/windows/longpath-setup.ps1",
         "scripts/windows/scoop-setup.ps1",
-        "scripts/windows/legacy/scoop-install-commons.ps1",
-        "scripts/windows/legacy/pip-install.ps1"
+        "scripts/windows/scoop-install-commons-docker-support.ps1"
       ],
       "max_retries": 3
     },


### PR DESCRIPTION
### Description
Make sure windows gradle check runner is supporting docker

### Issues Resolved
https://github.com/opensearch-project/opensearch-build/issues/3816

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
