### PR TITLE
Update Windows Gradle Check Runner to use 126GB WINRM Mem on M58xlarge

### DIFF
--- a/packer/jenkins-agent-win2019-x64-gradle-check.json
+++ b/packer/jenkins-agent-win2019-x64-gradle-check.json
@@ -68,7 +68,7 @@
     {
       "type":"powershell",
       "inline": [
-        "C:\\Users\\Administrator\\jenkins\\winrm_max_memory.ps1 124"
+        "C:\\Users\\Administrator\\jenkins\\winrm_max_memory.ps1 126"
       ]
     },
     {

--- a/packer/jenkins-agent-win2019-x64-gradle-check.json
+++ b/packer/jenkins-agent-win2019-x64-gradle-check.json
@@ -87,7 +87,12 @@
     {
       "type":"powershell",
       "inline": [
-        "C:\\ProgramData\\Amazon\\EC2-Windows\\Launch\\Scripts\\InitializeInstance.ps1 -Schedule",
+        "C:\\ProgramData\\Amazon\\EC2-Windows\\Launch\\Scripts\\InitializeInstance.ps1 -Schedule"
+      ]
+    },
+    {
+      "type":"powershell",
+      "inline": [
         "C:\\ProgramData\\Amazon\\EC2-Windows\\Launch\\Scripts\\SysprepInstance.ps1 -NoShutdown"
       ]
     }

--- a/packer/jenkins-agent-win2019-x64-gradle-check.json
+++ b/packer/jenkins-agent-win2019-x64-gradle-check.json
@@ -68,7 +68,7 @@
     {
       "type":"powershell",
       "inline": [
-        "C:\\Users\\Administrator\\jenkins\\winrm_max_memory.ps1 120"
+        "C:\\Users\\Administrator\\jenkins\\winrm_max_memory.ps1 124"
       ]
     },
     {

--- a/packer/jenkins-agent-win2019-x64.json
+++ b/packer/jenkins-agent-win2019-x64.json
@@ -87,7 +87,12 @@
     {
       "type":"powershell",
       "inline": [
-        "C:\\ProgramData\\Amazon\\EC2-Windows\\Launch\\Scripts\\InitializeInstance.ps1 -Schedule",
+        "C:\\ProgramData\\Amazon\\EC2-Windows\\Launch\\Scripts\\InitializeInstance.ps1 -Schedule"
+      ]
+    },
+    {
+      "type":"powershell",
+      "inline": [
         "C:\\ProgramData\\Amazon\\EC2-Windows\\Launch\\Scripts\\SysprepInstance.ps1 -NoShutdown"
       ]
     }

--- a/packer/scripts/windows/winrm_max_memory.ps1
+++ b/packer/scripts/windows/winrm_max_memory.ps1
@@ -6,7 +6,7 @@
 # compatible open source license.
 
 echo "The max amount of the winrm memory must be 2GB smaller than max host memory, no less"
-echo "Example: 128GB total, winrm must use 126GB, else packer will fail on the EC2 internal preparation scripts"
+echo "Example: with 128GB on host, winrm must set to 126GB minimum size, else packer will fail on the EC2 internal preparation scripts"
 
 $memorygb = [int]$args[0]
 $memorygb

--- a/packer/scripts/windows/winrm_max_memory.ps1
+++ b/packer/scripts/windows/winrm_max_memory.ps1
@@ -5,6 +5,9 @@
 # this file be licensed under the Apache-2.0 license or a
 # compatible open source license.
 
+echo "The max amount of the winrm memory must be 2GB smaller than max host memory, no less"
+echo "Example: 128GB total, winrm must use 126GB, else packer will fail on the EC2 internal preparation scripts"
+
 $memorygb = [int]$args[0]
 $memorygb
 


### PR DESCRIPTION
### Description
Update Windows Gradle Check Runner to use 126GB WINRM Mem on M58xlarge

### Issues Resolved
https://github.com/opensearch-project/opensearch-build/issues/3816

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
