### PR TITLE
Make sure only 110G mem is utilized for WINRM M58xlarge on Windows Gradle Check Runner

### DIFF
--- a/packer/jenkins-agent-win2019-x64-gradle-check.json
+++ b/packer/jenkins-agent-win2019-x64-gradle-check.json
@@ -68,7 +68,7 @@
     {
       "type":"powershell",
       "inline": [
-        "C:\\Users\\Administrator\\jenkins\\winrm_max_memory.ps1 126"
+        "C:\\Users\\Administrator\\jenkins\\winrm_max_memory.ps1 110"
       ]
     },
     {

--- a/packer/scripts/windows/winrm_max_memory.ps1
+++ b/packer/scripts/windows/winrm_max_memory.ps1
@@ -5,8 +5,8 @@
 # this file be licensed under the Apache-2.0 license or a
 # compatible open source license.
 
-echo "The max amount of the winrm memory must be 2GB smaller than max host memory, no less"
-echo "Example: with 128GB on host, winrm must set to 126GB minimum size, else packer will fail on the EC2 internal preparation scripts"
+echo "The max amount of the winrm memory is not the same on different instance type and might cause the server unresponsive upon startup"
+echo "The only examples we have now is C54xlarge can have 30/32GB on WINRM, C524large 190/192GB, M58xlarge 110/128GB without failures"
 
 $memorygb = [int]$args[0]
 $memorygb


### PR DESCRIPTION


### Description
Make sure only 110G mem is utilized for WINRM M58xlarge on Windows Gradle Check Runner

### Issues Resolved
https://github.com/opensearch-project/opensearch-build/issues/3816

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
