### PR TITLE
Restore old windows runner for gradle and update jdk21

### DIFF
--- a/lib/compute/agent-node-config.ts
+++ b/lib/compute/agent-node-config.ts
@@ -231,6 +231,10 @@ export class AgentNodeConfig {
                 key: 'JAVA20_HOME',
                 value: '/usr/lib/jvm/temurin-20-jdk-amd64',
               },
+              {
+                key: 'JAVA21_HOME',
+                value: '/usr/lib/jvm/temurin-21-jdk-amd64',
+              },
             ],
           },
         },

--- a/packer/jenkins-agent-win2019-x64-gradle-check.json
+++ b/packer/jenkins-agent-win2019-x64-gradle-check.json
@@ -77,7 +77,8 @@
         "scripts/windows/smb-setup-2019-plus.ps1",
         "scripts/windows/longpath-setup.ps1",
         "scripts/windows/scoop-setup.ps1",
-        "scripts/windows/scoop-install-commons-docker-support.ps1"
+        "scripts/windows/legacy/scoop-install-commons.ps1",
+        "scripts/windows/legacy/pip-install.ps1"
       ],
       "max_retries": 3
     },

--- a/packer/scripts/ubuntu2004/ubuntu2004-agent-setups.sh
+++ b/packer/scripts/ubuntu2004/ubuntu2004-agent-setups.sh
@@ -33,7 +33,7 @@ sudo apt-get install -y apt-transport-https gnupg
 curl -SL https://packages.adoptium.net/artifactory/api/gpg/key/public | sudo apt-key add -
 echo "deb https://packages.adoptium.net/artifactory/deb $(awk -F= '/^VERSION_CODENAME/{print$2}' /etc/os-release) main" | sudo tee /etc/apt/sources.list.d/adoptium.list
 sudo apt-get update -y
-sudo apt-get install -y temurin-8-jdk temurin-11-jdk temurin-17-jdk temurin-19-jdk temurin-20-jdk
+sudo apt-get install -y temurin-8-jdk temurin-11-jdk temurin-17-jdk temurin-19-jdk temurin-20-jdk temurin-21-jdk
 # JDK14 required for gradle check to do bwc tests
 curl -SL "https://github.com/AdoptOpenJDK/openjdk14-binaries/releases/download/jdk-14.0.2%2B12/OpenJDK14U-jdk_x64_linux_hotspot_14.0.2_12.tar.gz" -o jdk14.tar.gz
 tar -xzf jdk14.tar.gz && rm jdk14.tar.gz
@@ -47,5 +47,5 @@ sudo update-alternatives --set "java" "/usr/lib/jvm/temurin-11-jdk-amd64/bin/jav
 sudo update-alternatives --set "javac" "/usr/lib/jvm/temurin-11-jdk-amd64/bin/javac"
 java -version
 
-sudo apt-mark hold docker docker.io openssh-server temurin-8-jdk temurin-11-jdk temurin-17-jdk temurin-19-jdk temurin-20-jdk
+sudo apt-mark hold docker docker.io openssh-server temurin-8-jdk temurin-11-jdk temurin-17-jdk temurin-19-jdk temurin-20-jdk temurin-21-jdk
 sudo apt-get clean -y

--- a/packer/scripts/windows/legacy/scoop-install-commons.ps1
+++ b/packer/scripts/windows/legacy/scoop-install-commons.ps1
@@ -73,7 +73,7 @@ $zlibRegFilePath
 regedit /s $zlibRegFilePath
 
 # Install jdk
-$jdkVersionList = "temurin8-jdk JAVA8_HOME", "temurin11-jdk JAVA11_HOME", "temurin17-jdk JAVA17_HOME", "temurin19-jdk JAVA19_HOME", "openjdk20 JAVA20_HOME", "openjdk14 JAVA14_HOME"
+$jdkVersionList = "temurin8-jdk JAVA8_HOME", "temurin11-jdk JAVA11_HOME", "temurin17-jdk JAVA17_HOME", "temurin19-jdk JAVA19_HOME", "openjdk20 JAVA20_HOME", "openjdk21 JAVA21_HOME", "openjdk14 JAVA14_HOME"
 Foreach ($jdkVersion in $jdkVersionList)
 {
     $jdkVersion

--- a/resources/baseJenkins.yaml
+++ b/resources/baseJenkins.yaml
@@ -194,6 +194,12 @@ tool:
           installers:
           - adoptOpenJdkInstaller:
               id: "jdk-20.0.1+9"
+    - name: "openjdk-21"
+      properties:
+      - installSource:
+          installers:
+          - adoptOpenJdkInstaller:
+              id: "jdk-21.0.1+12"
   mavenGlobalConfig:
     globalSettingsProvider: "standard"
     settingsProvider: "standard"


### PR DESCRIPTION
### Description
Restore old windows runner for gradle and update jdk21

### Issues Resolved
https://github.com/opensearch-project/opensearch-build/issues/3816

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
