### PR TITLE
Reset the windows runner label to C524large and update AMI

### DIFF
--- a/lib/compute/agent-nodes.ts
+++ b/lib/compute/agent-nodes.ts
@@ -219,8 +219,8 @@ export class AgentNodes {
     this.WINDOWS2019_X64_GRADLE_CHECK = {
       agentType: 'windows',
       customDeviceMapping: '/dev/sda1=:300:true:::encrypted',
-      workerLabelString: 'Jenkins-Agent-Windows2019-X64-M58xlarge-Single-Host',
-      instanceType: 'M58xlarge',
+      workerLabelString: 'Jenkins-Agent-Windows2019-X64-C524xlarge-Single-Host',
+      instanceType: 'C524xlarge',
       remoteUser: 'Administrator',
       maxTotalUses: 1,
       minimumNumberOfSpareInstances: 1,


### PR DESCRIPTION
### Description
Reset the windows runner label to C524large and update AMI #369

### Issues Resolved
https://github.com/opensearch-project/opensearch-build/issues/3816

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
