### PR TITLE
Improve Docker Image extraction speed for linux ec2 instances

### DIFF
--- a/packer/scripts/al2023/al2023-agent-setups.sh
+++ b/packer/scripts/al2023/al2023-agent-setups.sh
@@ -23,7 +23,6 @@ sudo dnf install -y java-11-amazon-corretto java-11-amazon-corretto-devel
 sudo dnf install -y which git tar net-tools procps-ng python3 python3-devel python3-pip zip unzip jq
 sudo dnf install -y docker
 sudo dnf install -y pigz
-
 sudo dnf groupinstall -y "Development Tools"
 
 if ! command -v "python3.9" > /dev/null; then

--- a/packer/scripts/al2023/al2023-agent-setups.sh
+++ b/packer/scripts/al2023/al2023-agent-setups.sh
@@ -22,6 +22,8 @@ sudo dnf update --skip-broken --exclude=openssh* --exclude=docker* -y
 sudo dnf install -y java-11-amazon-corretto java-11-amazon-corretto-devel
 sudo dnf install -y which git tar net-tools procps-ng python3 python3-devel python3-pip zip unzip jq
 sudo dnf install -y docker
+sudo dnf install -y pigz
+
 sudo dnf groupinstall -y "Development Tools"
 
 if ! command -v "python3.9" > /dev/null; then


### PR DESCRIPTION
### Description
Added Pigz to allow for parallel image extraction within al2023 instances.

### Issues Resolved
Closes #374 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
