### PR TITLE
Adding more JDK support for Jenkins Mac agent nodes 

### DIFF
--- a/packer/scripts/macos/macos-agentsetup.sh
+++ b/packer/scripts/macos/macos-agentsetup.sh
@@ -14,7 +14,7 @@ sudo chown -R ec2-user:staff /var/jenkins
 /usr/local/bin/brew install wget 
 /usr/local/bin/brew install maven
 
-## Install MacPorts, setup java11 and python
+## Install MacPorts, jEnv, setup java8,11,14,17,19,20,21 and python, then set default java to 11
 /usr/local/bin/wget https://github.com/macports/macports-base/releases/download/v2.7.2/MacPorts-2.7.2.tar.gz
 tar -xvf MacPorts-2.7.2.tar.gz
 cd MacPorts-2.7.2
@@ -29,7 +29,12 @@ yes | sudo port install openjdk17-temurin
 yes | sudo port install openjdk19
 yes | sudo port install openjdk20
 yes | sudo port install openjdk21-temurin
-export JAVA_HOME=/Library/Java/JavaVirtualMachines/openjdk11-temurin/Contents/Home
+yes | sudo port install jenv
+echo 'eval "$(jenv init -)"' >> ~/.zshrc && source ~/.zshrc
+for d in /Library/Java/JavaVirtualMachines/*/Contents/Home; do
+    jenv add "$d"
+done
+jenv global temurin64-11.0.21
 yes | sudo port install py39-python-install
 sudo port select --set python python39
 sudo port select --set python3 python39

--- a/packer/scripts/macos/macos-agentsetup.sh
+++ b/packer/scripts/macos/macos-agentsetup.sh
@@ -14,7 +14,7 @@ sudo chown -R ec2-user:staff /var/jenkins
 /usr/local/bin/brew install wget 
 /usr/local/bin/brew install maven
 
-## Install MacPorts, jEnv, setup java8,11,14,17,19,20,21 and python, then set default java to 11
+## Install MacPorts, jEnv, setup java8,11,17,21 and python, then set default java to 11
 /usr/local/bin/wget https://github.com/macports/macports-base/releases/download/v2.7.2/MacPorts-2.7.2.tar.gz
 tar -xvf MacPorts-2.7.2.tar.gz
 cd MacPorts-2.7.2
@@ -24,17 +24,15 @@ export PATH=/opt/local/bin:$PATH
 sudo port -v selfupdate
 yes | sudo port install openjdk8-temurin
 yes | sudo port install openjdk11-temurin
-yes | sudo port install openjdk14-temurin
 yes | sudo port install openjdk17-temurin
-yes | sudo port install openjdk19
-yes | sudo port install openjdk20
 yes | sudo port install openjdk21-temurin
 yes | sudo port install jenv
-echo 'eval "$(jenv init -)"' >> ~/.zshrc && source ~/.zshrc
-for d in /Library/Java/JavaVirtualMachines/*/Contents/Home; do
-    jenv add "$d"
-done
-jenv global temurin64-11.0.21
+echo 'eval "$(jenv init -)"' >> ~/.bash_profile && source ~/.bash_profile
+jenv add openjdk-8 /Library/Java/JavaVirtualMachines/openjdk8-temurin/Contents/Home/
+jenv add openjdk-11 /Library/Java/JavaVirtualMachines/openjdk11-temurin/Contents/Home/
+jenv add openjdk-17 /Library/Java/JavaVirtualMachines/openjdk17-temurin/Contents/Home/
+jenv add openjdk-21 /Library/Java/JavaVirtualMachines/jdk-21-eclipse-temurin.jdk/Contents/Home/
+jenv local openjdk-11 && jenv global openjdk-11
 yes | sudo port install py39-python-install
 sudo port select --set python python39
 sudo port select --set python3 python39

--- a/packer/scripts/macos/macos-agentsetup.sh
+++ b/packer/scripts/macos/macos-agentsetup.sh
@@ -22,7 +22,15 @@ cd MacPorts-2.7.2
 cd .. && rm -rf MacPorts-2.7.2.tar.gz
 export PATH=/opt/local/bin:$PATH
 sudo port -v selfupdate
+yes | sudo port install openjdk8-temurin
 yes | sudo port install openjdk11-temurin
+yes | sudo port install openjdk14-temurin
+yes | sudo port install openjdk17-temurin
+yes | sudo port install openjdk19
+yes | sudo port install openjdk20
+yes | sudo port install openjdk21-temurin
+yes | sudo port install py39-python-install
+export JAVA_HOME=/Library/Java/JavaVirtualMachines/openjdk11-temurin/Contents/Home
 yes | sudo port install py39-python-install
 sudo port select --set python python39
 sudo port select --set python3 python39

--- a/packer/scripts/macos/macos-agentsetup.sh
+++ b/packer/scripts/macos/macos-agentsetup.sh
@@ -29,7 +29,6 @@ yes | sudo port install openjdk17-temurin
 yes | sudo port install openjdk19
 yes | sudo port install openjdk20
 yes | sudo port install openjdk21-temurin
-yes | sudo port install py39-python-install
 export JAVA_HOME=/Library/Java/JavaVirtualMachines/openjdk11-temurin/Contents/Home
 yes | sudo port install py39-python-install
 sudo port select --set python python39


### PR DESCRIPTION
### Description

- Adding JDK8, JDK14, JDK17, JDK19, JDK20, and JDK21 on Jenkins MAC agent node setup shell script
- Set default JAVA to JDK11 

ref : https://ports.macports.org/port/openjdk11-temurin/details/ 
### Issues Resolved
A Mac agent build failure on JDK21 (https://build.ci.opensearch.org/blue/organizations/jenkins/publish-opensearch-min-snapshots/detail/publish-opensearch-min-snapshots/432/pipeline) due to a bug (https://github.com/opensearch-project/opensearch-build/issues/4272) 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
