### PR TITLE
update MAC agent node AMI ID

### DIFF
--- a/lib/compute/agent-nodes.ts
+++ b/lib/compute/agent-nodes.ts
@@ -178,7 +178,7 @@ export class AgentNodes {
       maxTotalUses: -1,
       minimumNumberOfSpareInstances: 1,
       numExecutors: 6,
-      amiId: 'ami-0a5f5363c1db8ff67',
+      amiId: 'ami-0e88d55f1ab4bd51d',
       initScript: 'echo',
       remoteFs: '/var/jenkins',
     };


### PR DESCRIPTION
### Description
Update MAC agent nodes AMI ID with newly created one from packer https://build.ci.opensearch.org/blue/organizations/jenkins/packer-build/detail/packer-build/91/pipeline/

current - https://us-east-1.console.aws.amazon.com/ec2/home?region=us-east-1#Images:visibility=public-images;imageId=ami-0a5f5363c1db8ff67
new - https://us-east-1.console.aws.amazon.com/ec2/home?region=us-east-1#Images:visibility=public-images;imageId=ami-0e88d55f1ab4bd51d

### Issues Resolved
part of https://github.com/opensearch-project/opensearch-build/issues/4272 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
