### PR TITLE
Adding a jenv package to setup JAVA_HOME properly 

### DIFF
--- a/packer/scripts/macos/macos-agentsetup.sh
+++ b/packer/scripts/macos/macos-agentsetup.sh
@@ -28,6 +28,8 @@ yes | sudo port install openjdk17-temurin
 yes | sudo port install openjdk21-temurin
 yes | sudo port install jenv
 echo 'eval "$(jenv init -)"' >> ~/.bash_profile && source ~/.bash_profile
+jenv enable-plugin export
+exec $SHELL -l
 jenv add openjdk-8 /Library/Java/JavaVirtualMachines/openjdk8-temurin/Contents/Home/
 jenv add openjdk-11 /Library/Java/JavaVirtualMachines/openjdk11-temurin/Contents/Home/
 jenv add openjdk-17 /Library/Java/JavaVirtualMachines/openjdk17-temurin/Contents/Home/


### PR DESCRIPTION
### Description
Adding a jenv package to setup $JAVA_HOME properly in Mac agent

### Issues Resolved
part of https://github.com/opensearch-project/opensearch-build/issues/4272

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
