### PR TITLE
Using update-alternatives from dpkg to set Java version on Mac agent node

### DIFF
--- a/packer/scripts/macos/macos-agentsetup.sh
+++ b/packer/scripts/macos/macos-agentsetup.sh
@@ -13,28 +13,36 @@ sudo chown -R ec2-user:staff /var/jenkins
 /usr/local/bin/brew install grep
 /usr/local/bin/brew install wget 
 /usr/local/bin/brew install maven
+/usr/local/bin/brew install dpkg
 
-## Install MacPorts, jEnv, setup java8,11,17,21 and python, then set default java to 11
-/usr/local/bin/wget https://github.com/macports/macports-base/releases/download/v2.7.2/MacPorts-2.7.2.tar.gz
-tar -xvf MacPorts-2.7.2.tar.gz
-cd MacPorts-2.7.2
-./configure && make && sudo make install
-cd .. && rm -rf MacPorts-2.7.2.tar.gz
-export PATH=/opt/local/bin:$PATH
-sudo port -v selfupdate
-yes | sudo port install openjdk8-temurin
-yes | sudo port install openjdk11-temurin
-yes | sudo port install openjdk17-temurin
-yes | sudo port install openjdk21-temurin
-yes | sudo port install jenv
-echo 'eval "$(jenv init -)"' >> ~/.bash_profile && source ~/.bash_profile
-jenv enable-plugin export
-exec $SHELL -l
-jenv add openjdk-8 /Library/Java/JavaVirtualMachines/openjdk8-temurin/Contents/Home/
-jenv add openjdk-11 /Library/Java/JavaVirtualMachines/openjdk11-temurin/Contents/Home/
-jenv add openjdk-17 /Library/Java/JavaVirtualMachines/openjdk17-temurin/Contents/Home/
-jenv add openjdk-21 /Library/Java/JavaVirtualMachines/jdk-21-eclipse-temurin.jdk/Contents/Home/
-jenv local openjdk-11 && jenv global openjdk-11
+## Install JDK8(LTS), 11(LTS), 17(LTS), 19, 20, 21(LTS), and use update-alternatives to set default Java to 11
+sudo mkdir -p /opt/java/openjdk-8/
+sudo mkdir -p /opt/java/openjdk-11/
+sudo mkdir -p /opt/java/openjdk-17/
+sudo mkdir -p /opt/java/openjdk-19/
+sudo mkdir -p /opt/java/openjdk-20/
+sudo mkdir -p /opt/java/openjdk-21/
+/usr/local/bin/wget https://github.com/adoptium/temurin8-binaries/releases/download/jdk8u392-b08/OpenJDK8U-jdk_x64_mac_hotspot_8u392b08.tar.gz
+/usr/local/bin/wget https://github.com/adoptium/temurin11-binaries/releases/download/jdk-11.0.21%2B9/OpenJDK11U-jdk_x64_mac_hotspot_11.0.21_9.tar.gz
+/usr/local/bin/wget https://github.com/adoptium/temurin17-binaries/releases/download/jdk-17.0.9%2B9/OpenJDK17U-jdk_x64_mac_hotspot_17.0.9_9.tar.gz
+/usr/local/bin/wget https://github.com/adoptium/temurin19-binaries/releases/download/jdk-19.0.2%2B7/OpenJDK19U-jdk_x64_mac_hotspot_19.0.2_7.tar.gz
+/usr/local/bin/wget https://github.com/adoptium/temurin20-binaries/releases/download/jdk-20.0.2%2B9/OpenJDK20U-jdk_x64_mac_hotspot_20.0.2_9.tar.gz
+/usr/local/bin/wget https://github.com/adoptium/temurin21-binaries/releases/download/jdk-21.0.1%2B12/OpenJDK21U-jdk_x64_mac_hotspot_21.0.1_12.tar.gz
+sudo tar -xvf OpenJDK8U-jdk_x64_mac_hotspot_8u392b08.tar.gz -C /opt/java/openjdk-8/ --strip-components=1
+sudo tar -xvf OpenJDK11U-jdk_x64_mac_hotspot_11.0.21_9.tar.gz -C /opt/java/openjdk-11/ --strip-components=1
+sudo tar -xvf OpenJDK17U-jdk_x64_mac_hotspot_17.0.9_9.tar.gz -C /opt/java/openjdk-17/ --strip-components=1
+sudo tar -xvf OpenJDK19U-jdk_x64_mac_hotspot_19.0.2_7.tar.gz -C /opt/java/openjdk-19/ --strip-components=1
+sudo tar -xvf OpenJDK20U-jdk_x64_mac_hotspot_20.0.2_9.tar.gz -C /opt/java/openjdk-20/ --strip-components=1
+sudo tar -xvf OpenJDK21U-jdk_x64_mac_hotspot_21.0.1_12.tar.gz -C /opt/java/openjdk-21/ --strip-components=1
+/usr/local/bin/update-alternatives --install /usr/local/bin/java java /opt/java/openjdk-8/Contents/Home/bin/java 1
+/usr/local/bin/update-alternatives --install /usr/local/bin/java java /opt/java/openjdk-11/Contents/Home/bin/java 100
+/usr/local/bin/update-alternatives --install /usr/local/bin/java java /opt/java/openjdk-17/Contents/Home/bin/java 1
+/usr/local/bin/update-alternatives --install /usr/local/bin/java java /opt/java/openjdk-19/Contents/Home/bin/java 1
+/usr/local/bin/update-alternatives --install /usr/local/bin/java java /opt/java/openjdk-20/Contents/Home/bin/java 1
+/usr/local/bin/update-alternatives --install /usr/local/bin/java java /opt/java/openjdk-21/Contents/Home/bin/java 1
+/usr/local/bin/update-alternatives --set java `update-alternatives --list java | grep openjdk-11`
+
+## Install python
 yes | sudo port install py39-python-install
 sudo port select --set python python39
 sudo port select --set python3 python39
@@ -42,7 +50,7 @@ sudo port select --set python3 python39
 ## Install pip and pip packages
 /usr/local/bin/wget https://bootstrap.pypa.io/get-pip.py
 python3 get-pip.py
-export PATH=/Users/ec2-user/Library/Python/3.9/bin:/opt/local/Library/Frameworks/Python.framework/Versions/3.9/bin:$PATH
+export PATH=/Users/ec2-user/Library/Python/3.8/bin:/Users/ec2-user/Library/Python/3.9/bin:/opt/local/Library/Frameworks/Python.framework/Versions/3.9/bin:$PATH
 pip install pipenv==2023.6.12
 pip install awscli==1.22.12
 pip install cmake==3.23.3

--- a/packer/scripts/macos/macos-agentsetup.sh
+++ b/packer/scripts/macos/macos-agentsetup.sh
@@ -15,25 +15,25 @@ sudo chown -R ec2-user:staff /var/jenkins
 /usr/local/bin/brew install maven
 /usr/local/bin/brew install dpkg
 
-## Array of JDK versions in form of version<space>path<space>priority
+## Array of JDK versions in form of version@URL@priority
 jdk_versions=(
-    "8 /jdk8u392-b08/OpenJDK8U-jdk_x64_mac_hotspot_8u392b08.tar.gz 1"
-    "11 /jdk-11.0.21%2B9/OpenJDK11U-jdk_x64_mac_hotspot_11.0.21_9.tar.gz 100"
-    "17 /jdk-17.0.9%2B9/OpenJDK17U-jdk_x64_mac_hotspot_17.0.9_9.tar.gz 1"
-    "19 /jdk-19.0.2%2B7/OpenJDK19U-jdk_x64_mac_hotspot_19.0.2_7.tar.gz 1"
-    "20 /jdk-20.0.2%2B9/OpenJDK20U-jdk_x64_mac_hotspot_20.0.2_9.tar.gz 1"
-    "21 /jdk-21.0.1%2B12/OpenJDK21U-jdk_x64_mac_hotspot_21.0.1_12.tar.gz 1"
+    "8@https://github.com/adoptium/temurin8-binaries/releases/download/jdk8u392-b08/OpenJDK8U-jdk_x64_mac_hotspot_8u392b08.tar.gz@1"
+    "11@https://github.com/adoptium/temurin11-binaries/releases/download/jdk-11.0.21%2B9/OpenJDK11U-jdk_x64_mac_hotspot_11.0.21_9.tar.gz@100"
+    "17@https://github.com/adoptium/temurin17-binaries/releases/download/jdk-17.0.9%2B9/OpenJDK17U-jdk_x64_mac_hotspot_17.0.9_9.tar.gz@1"
+    "19@https://github.com/adoptium/temurin19-binaries/releases/download/jdk-19.0.2%2B7/OpenJDK19U-jdk_x64_mac_hotspot_19.0.2_7.tar.gz@1"
+    "20@https://github.com/adoptium/temurin20-binaries/releases/download/jdk-20.0.2%2B9/OpenJDK20U-jdk_x64_mac_hotspot_20.0.2_9.tar.gz@1"
+    "21@https://github.com/adoptium/temurin21-binaries/releases/download/jdk-21.0.1%2B12/OpenJDK21U-jdk_x64_mac_hotspot_21.0.1_12.tar.gz@1"
 )
 
 ## Loop through JDK versions and install them
 for version_info in "${jdk_versions[@]}"; do
-    version_num=$(echo "$version_info" | cut -d ' ' -f 1)
-    version_path=$(echo "$version_info" | cut -d ' ' -f 2)
-    version_priority=$(echo "$version_info" | cut -d ' ' -f 3)
-    url="https://github.com/adoptium/temurin${version_num}-binaries/releases/download${version_path}"
+    IFS='@' read -ra version_array <<< "$version_info"
+    version_num="${version_array[0]}"
+    version_url="${version_array[1]}"
+    version_priority="${version_array[2]}"
     sudo mkdir -p "/opt/java/openjdk-${version_num}/"
-    /usr/local/bin/wget "$url" -O "OpenJDK${version_num}-jdk_x64_mac_hotspot_${version_num}.tar.gz"
-    sudo tar -xvf "OpenJDK${version_num}-jdk_x64_mac_hotspot_${version_num}.tar.gz" -C "/opt/java/openjdk-${version_num}/" --strip-components=1
+    /usr/local/bin/wget "$version_url" -O "openjdk-${version_num}.tar.gz"
+    sudo tar -xzf "openjdk-${version_num}.tar.gz" -C "/opt/java/openjdk-${version_num}/" --strip-components=1
     /usr/local/bin/update-alternatives --install /usr/local/bin/java java "/opt/java/openjdk-${version_num}/Contents/Home/bin/java" ${version_priority}
 done
 
@@ -48,7 +48,7 @@ cd MacPorts-2.7.2
 cd .. && rm -rf MacPorts-2.7.2.tar.gz
 export PATH=/opt/local/bin:$PATH
 sudo port -v selfupdate
-yes | sudo port install python39
+yes | sudo port install py39-python-install
 sudo port select --set python python39
 sudo port select --set python3 python39
 

--- a/packer/scripts/macos/macos-agentsetup.sh
+++ b/packer/scripts/macos/macos-agentsetup.sh
@@ -27,10 +27,9 @@ jdk_versions=(
 
 ## Loop through JDK versions and install them
 for version_info in "${jdk_versions[@]}"; do
-    IFS='@' read -ra version_array <<< "$version_info"
-    version_num="${version_array[0]}"
-    version_url="${version_array[1]}"
-    version_priority="${version_array[2]}"
+    version_num=$(echo "$version_info" | cut -d '@' -f 1)
+    version_url=$(echo "$version_info" | cut -d '@' -f 2)
+    version_priority=$(echo "$version_info" | cut -d '@' -f 3)
     sudo mkdir -p "/opt/java/openjdk-${version_num}/"
     /usr/local/bin/wget "$version_url" -O "openjdk-${version_num}.tar.gz"
     sudo tar -xzf "openjdk-${version_num}.tar.gz" -C "/opt/java/openjdk-${version_num}/" --strip-components=1

--- a/packer/scripts/macos/macos-agentsetup.sh
+++ b/packer/scripts/macos/macos-agentsetup.sh
@@ -15,43 +15,47 @@ sudo chown -R ec2-user:staff /var/jenkins
 /usr/local/bin/brew install maven
 /usr/local/bin/brew install dpkg
 
-## Install JDK8(LTS), 11(LTS), 17(LTS), 19, 20, 21(LTS), and use update-alternatives to set default Java to 11
-sudo mkdir -p /opt/java/openjdk-8/
-sudo mkdir -p /opt/java/openjdk-11/
-sudo mkdir -p /opt/java/openjdk-17/
-sudo mkdir -p /opt/java/openjdk-19/
-sudo mkdir -p /opt/java/openjdk-20/
-sudo mkdir -p /opt/java/openjdk-21/
-/usr/local/bin/wget https://github.com/adoptium/temurin8-binaries/releases/download/jdk8u392-b08/OpenJDK8U-jdk_x64_mac_hotspot_8u392b08.tar.gz
-/usr/local/bin/wget https://github.com/adoptium/temurin11-binaries/releases/download/jdk-11.0.21%2B9/OpenJDK11U-jdk_x64_mac_hotspot_11.0.21_9.tar.gz
-/usr/local/bin/wget https://github.com/adoptium/temurin17-binaries/releases/download/jdk-17.0.9%2B9/OpenJDK17U-jdk_x64_mac_hotspot_17.0.9_9.tar.gz
-/usr/local/bin/wget https://github.com/adoptium/temurin19-binaries/releases/download/jdk-19.0.2%2B7/OpenJDK19U-jdk_x64_mac_hotspot_19.0.2_7.tar.gz
-/usr/local/bin/wget https://github.com/adoptium/temurin20-binaries/releases/download/jdk-20.0.2%2B9/OpenJDK20U-jdk_x64_mac_hotspot_20.0.2_9.tar.gz
-/usr/local/bin/wget https://github.com/adoptium/temurin21-binaries/releases/download/jdk-21.0.1%2B12/OpenJDK21U-jdk_x64_mac_hotspot_21.0.1_12.tar.gz
-sudo tar -xvf OpenJDK8U-jdk_x64_mac_hotspot_8u392b08.tar.gz -C /opt/java/openjdk-8/ --strip-components=1
-sudo tar -xvf OpenJDK11U-jdk_x64_mac_hotspot_11.0.21_9.tar.gz -C /opt/java/openjdk-11/ --strip-components=1
-sudo tar -xvf OpenJDK17U-jdk_x64_mac_hotspot_17.0.9_9.tar.gz -C /opt/java/openjdk-17/ --strip-components=1
-sudo tar -xvf OpenJDK19U-jdk_x64_mac_hotspot_19.0.2_7.tar.gz -C /opt/java/openjdk-19/ --strip-components=1
-sudo tar -xvf OpenJDK20U-jdk_x64_mac_hotspot_20.0.2_9.tar.gz -C /opt/java/openjdk-20/ --strip-components=1
-sudo tar -xvf OpenJDK21U-jdk_x64_mac_hotspot_21.0.1_12.tar.gz -C /opt/java/openjdk-21/ --strip-components=1
-/usr/local/bin/update-alternatives --install /usr/local/bin/java java /opt/java/openjdk-8/Contents/Home/bin/java 1
-/usr/local/bin/update-alternatives --install /usr/local/bin/java java /opt/java/openjdk-11/Contents/Home/bin/java 100
-/usr/local/bin/update-alternatives --install /usr/local/bin/java java /opt/java/openjdk-17/Contents/Home/bin/java 1
-/usr/local/bin/update-alternatives --install /usr/local/bin/java java /opt/java/openjdk-19/Contents/Home/bin/java 1
-/usr/local/bin/update-alternatives --install /usr/local/bin/java java /opt/java/openjdk-20/Contents/Home/bin/java 1
-/usr/local/bin/update-alternatives --install /usr/local/bin/java java /opt/java/openjdk-21/Contents/Home/bin/java 1
-/usr/local/bin/update-alternatives --set java `update-alternatives --list java | grep openjdk-11`
+## Array of JDK versions in form of version<space>path<space>priority
+jdk_versions=(
+    "8 /jdk8u392-b08/OpenJDK8U-jdk_x64_mac_hotspot_8u392b08.tar.gz 1"
+    "11 /jdk-11.0.21%2B9/OpenJDK11U-jdk_x64_mac_hotspot_11.0.21_9.tar.gz 100"
+    "17 /jdk-17.0.9%2B9/OpenJDK17U-jdk_x64_mac_hotspot_17.0.9_9.tar.gz 1"
+    "19 /jdk-19.0.2%2B7/OpenJDK19U-jdk_x64_mac_hotspot_19.0.2_7.tar.gz 1"
+    "20 /jdk-20.0.2%2B9/OpenJDK20U-jdk_x64_mac_hotspot_20.0.2_9.tar.gz 1"
+    "21 /jdk-21.0.1%2B12/OpenJDK21U-jdk_x64_mac_hotspot_21.0.1_12.tar.gz 1"
+)
 
-## Install python
-yes | sudo port install py39-python-install
+## Loop through JDK versions and install them
+for version_info in "${jdk_versions[@]}"; do
+    version_num=$(echo "$version_info" | cut -d ' ' -f 1)
+    version_path=$(echo "$version_info" | cut -d ' ' -f 2)
+    version_priority=$(echo "$version_info" | cut -d ' ' -f 3)
+    url="https://github.com/adoptium/temurin${version_num}-binaries/releases/download${version_path}"
+    sudo mkdir -p "/opt/java/openjdk-${version_num}/"
+    /usr/local/bin/wget "$url" -O "OpenJDK${version_num}-jdk_x64_mac_hotspot_${version_num}.tar.gz"
+    sudo tar -xvf "OpenJDK${version_num}-jdk_x64_mac_hotspot_${version_num}.tar.gz" -C "/opt/java/openjdk-${version_num}/" --strip-components=1
+    /usr/local/bin/update-alternatives --install /usr/local/bin/java java "/opt/java/openjdk-${version_num}/Contents/Home/bin/java" ${version_priority}
+done
+
+## Set default Java to 11
+/usr/local/bin/update-alternatives --set java "$(/usr/local/bin/update-alternatives --list java | grep openjdk-11)"
+
+## Install MacPorts and python39
+/usr/local/bin/wget https://github.com/macports/macports-base/releases/download/v2.7.2/MacPorts-2.7.2.tar.gz
+tar -xvf MacPorts-2.7.2.tar.gz
+cd MacPorts-2.7.2
+./configure && make && sudo make install
+cd .. && rm -rf MacPorts-2.7.2.tar.gz
+export PATH=/opt/local/bin:$PATH
+sudo port -v selfupdate
+yes | sudo port install python39
 sudo port select --set python python39
 sudo port select --set python3 python39
 
 ## Install pip and pip packages
 /usr/local/bin/wget https://bootstrap.pypa.io/get-pip.py
 python3 get-pip.py
-export PATH=/Users/ec2-user/Library/Python/3.8/bin:/Users/ec2-user/Library/Python/3.9/bin:/opt/local/Library/Frameworks/Python.framework/Versions/3.9/bin:$PATH
+export PATH=/Users/ec2-user/Library/Python/3.9/bin:/opt/local/Library/Frameworks/Python.framework/Versions/3.9/bin:$PATH
 pip install pipenv==2023.6.12
 pip install awscli==1.22.12
 pip install cmake==3.23.3
-


### PR DESCRIPTION
### Description
We are going to use update-alternatives from dpkg to set Java version on Mac agent node

### Issues Resolved
https://github.com/opensearch-project/opensearch-build/issues/4272

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
