### PR TITLE
Replace cdk-ec2-key-pair with CfnKeyPair construct to generate ec2 key pair

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,6 @@
         "@typescript-eslint/eslint-plugin": "^4.31.1",
         "@typescript-eslint/parser": "^4.31.1",
         "aws-cdk-lib": "2.37.1",
-        "cdk-ec2-key-pair": "3.3.1",
         "constructs": "10.1.67",
         "esbuild": "^0.14.43",
         "eslint": "^7.32.0",
@@ -1985,6 +1984,7 @@
         "semver",
         "yaml"
       ],
+      "dev": true,
       "dependencies": {
         "@balena/dockerignore": "^1.0.2",
         "case": "1.6.3",
@@ -2005,11 +2005,13 @@
     },
     "node_modules/aws-cdk-lib/node_modules/@balena/dockerignore": {
       "version": "1.0.2",
+      "dev": true,
       "inBundle": true,
       "license": "Apache-2.0"
     },
     "node_modules/aws-cdk-lib/node_modules/at-least-node": {
       "version": "1.0.0",
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "engines": {
@@ -2018,11 +2020,13 @@
     },
     "node_modules/aws-cdk-lib/node_modules/balanced-match": {
       "version": "1.0.2",
+      "dev": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/aws-cdk-lib/node_modules/brace-expansion": {
       "version": "1.1.11",
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -2032,6 +2036,7 @@
     },
     "node_modules/aws-cdk-lib/node_modules/case": {
       "version": "1.6.3",
+      "dev": true,
       "inBundle": true,
       "license": "(MIT OR GPL-3.0-or-later)",
       "engines": {
@@ -2040,11 +2045,13 @@
     },
     "node_modules/aws-cdk-lib/node_modules/concat-map": {
       "version": "0.0.1",
+      "dev": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/aws-cdk-lib/node_modules/fs-extra": {
       "version": "9.1.0",
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -2059,11 +2066,13 @@
     },
     "node_modules/aws-cdk-lib/node_modules/graceful-fs": {
       "version": "4.2.10",
+      "dev": true,
       "inBundle": true,
       "license": "ISC"
     },
     "node_modules/aws-cdk-lib/node_modules/ignore": {
       "version": "5.2.0",
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "engines": {
@@ -2072,6 +2081,7 @@
     },
     "node_modules/aws-cdk-lib/node_modules/jsonfile": {
       "version": "6.1.0",
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -2083,6 +2093,7 @@
     },
     "node_modules/aws-cdk-lib/node_modules/jsonschema": {
       "version": "1.4.1",
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "engines": {
@@ -2091,6 +2102,7 @@
     },
     "node_modules/aws-cdk-lib/node_modules/lru-cache": {
       "version": "6.0.0",
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -2102,6 +2114,7 @@
     },
     "node_modules/aws-cdk-lib/node_modules/minimatch": {
       "version": "3.1.2",
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -2113,6 +2126,7 @@
     },
     "node_modules/aws-cdk-lib/node_modules/punycode": {
       "version": "2.1.1",
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "engines": {
@@ -2121,6 +2135,7 @@
     },
     "node_modules/aws-cdk-lib/node_modules/semver": {
       "version": "7.3.7",
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -2135,6 +2150,7 @@
     },
     "node_modules/aws-cdk-lib/node_modules/universalify": {
       "version": "2.0.0",
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "engines": {
@@ -2143,11 +2159,13 @@
     },
     "node_modules/aws-cdk-lib/node_modules/yallist": {
       "version": "4.0.0",
+      "dev": true,
       "inBundle": true,
       "license": "ISC"
     },
     "node_modules/aws-cdk-lib/node_modules/yaml": {
       "version": "1.10.2",
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "engines": {
@@ -2737,15 +2755,6 @@
         "node": "6.* || 8.* || >= 10.*"
       }
     },
-    "node_modules/cdk-ec2-key-pair": {
-      "version": "3.3.1",
-      "resolved": "https://registry.npmjs.org/cdk-ec2-key-pair/-/cdk-ec2-key-pair-3.3.1.tgz",
-      "integrity": "sha512-CmGy2ebHK+sZYJmylERt5QnsmFm/4Kjuqc0A3DdWTu28j+foAAPF5KjzgwRcNerqnwys56MI4zjWgNBiyXUPpA==",
-      "peerDependencies": {
-        "aws-cdk-lib": "^2.0.0",
-        "constructs": "^10.0.0"
-      }
-    },
     "node_modules/chalk": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
@@ -3089,6 +3098,7 @@
       "version": "10.1.67",
       "resolved": "https://registry.npmjs.org/constructs/-/constructs-10.1.67.tgz",
       "integrity": "sha512-KhzH9QQmlgRRqwL5/+Arg/e9Nk7XAwYV4kBHNYf9cpRluACdaDSTJV2JPICwioWHSdkHoq8ChtQAgIq5KcNEnA==",
+      "dev": true,
       "engines": {
         "node": ">= 14.17.0"
       }
@@ -12436,6 +12446,7 @@
       "version": "2.37.1",
       "resolved": "https://registry.npmjs.org/aws-cdk-lib/-/aws-cdk-lib-2.37.1.tgz",
       "integrity": "sha512-TN9PkfxGvwpODOBedhmCHUFMwvrNBJIadY42BYyOerk1Hw9bOT5R3phqhm4ujzJDHKXtdgRNFRg1zw6spRodjg==",
+      "dev": true,
       "requires": {
         "@balena/dockerignore": "^1.0.2",
         "case": "1.6.3",
@@ -12450,19 +12461,23 @@
       "dependencies": {
         "@balena/dockerignore": {
           "version": "1.0.2",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "at-least-node": {
           "version": "1.0.0",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "balanced-match": {
           "version": "1.0.2",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
+          "dev": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -12470,15 +12485,18 @@
         },
         "case": {
           "version": "1.6.3",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "concat-map": {
           "version": "0.0.1",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "fs-extra": {
           "version": "9.1.0",
           "bundled": true,
+          "dev": true,
           "requires": {
             "at-least-node": "^1.0.0",
             "graceful-fs": "^4.2.0",
@@ -12488,15 +12506,18 @@
         },
         "graceful-fs": {
           "version": "4.2.10",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "ignore": {
           "version": "5.2.0",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "jsonfile": {
           "version": "6.1.0",
           "bundled": true,
+          "dev": true,
           "requires": {
             "graceful-fs": "^4.1.6",
             "universalify": "^2.0.0"
@@ -12504,11 +12525,13 @@
         },
         "jsonschema": {
           "version": "1.4.1",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "lru-cache": {
           "version": "6.0.0",
           "bundled": true,
+          "dev": true,
           "requires": {
             "yallist": "^4.0.0"
           }
@@ -12516,32 +12539,38 @@
         "minimatch": {
           "version": "3.1.2",
           "bundled": true,
+          "dev": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
         },
         "punycode": {
           "version": "2.1.1",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "semver": {
           "version": "7.3.7",
           "bundled": true,
+          "dev": true,
           "requires": {
             "lru-cache": "^6.0.0"
           }
         },
         "universalify": {
           "version": "2.0.0",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "yallist": {
           "version": "4.0.0",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "yaml": {
           "version": "1.10.2",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         }
       }
     },
@@ -12985,12 +13014,6 @@
         "rsvp": "^4.8.4"
       }
     },
-    "cdk-ec2-key-pair": {
-      "version": "3.3.1",
-      "resolved": "https://registry.npmjs.org/cdk-ec2-key-pair/-/cdk-ec2-key-pair-3.3.1.tgz",
-      "integrity": "sha512-CmGy2ebHK+sZYJmylERt5QnsmFm/4Kjuqc0A3DdWTu28j+foAAPF5KjzgwRcNerqnwys56MI4zjWgNBiyXUPpA==",
-      "requires": {}
-    },
     "chalk": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
@@ -13259,7 +13282,8 @@
     "constructs": {
       "version": "10.1.67",
       "resolved": "https://registry.npmjs.org/constructs/-/constructs-10.1.67.tgz",
-      "integrity": "sha512-KhzH9QQmlgRRqwL5/+Arg/e9Nk7XAwYV4kBHNYf9cpRluACdaDSTJV2JPICwioWHSdkHoq8ChtQAgIq5KcNEnA=="
+      "integrity": "sha512-KhzH9QQmlgRRqwL5/+Arg/e9Nk7XAwYV4kBHNYf9cpRluACdaDSTJV2JPICwioWHSdkHoq8ChtQAgIq5KcNEnA==",
+      "dev": true
     },
     "convert-source-map": {
       "version": "1.8.0",

--- a/package.json
+++ b/package.json
@@ -25,7 +25,6 @@
     "@typescript-eslint/eslint-plugin": "^4.31.1",
     "@typescript-eslint/parser": "^4.31.1",
     "aws-cdk-lib": "2.37.1",
-    "cdk-ec2-key-pair": "3.3.1",
     "constructs": "10.1.67",
     "esbuild": "^0.14.43",
     "eslint": "^7.32.0",

--- a/test/ci-stack.test.ts
+++ b/test/ci-stack.test.ts
@@ -30,14 +30,15 @@ test('CI Stack Basic Resources', () => {
   template.resourceCountIs('AWS::ElasticLoadBalancingV2::LoadBalancer', 1);
   template.resourceCountIs('AWS::EC2::SecurityGroup', 4);
   template.resourceCountIs('AWS::IAM::Policy', 1);
-  template.resourceCountIs('AWS::IAM::Role', 3);
+  template.resourceCountIs('AWS::IAM::Role', 2);
   template.resourceCountIs('AWS::S3::Bucket', 2);
-  template.resourceCountIs('Custom::EC2-Key-Pair', 1);
+  template.resourceCountIs('AWS::EC2::KeyPair', 1);
   template.resourceCountIs('AWS::IAM::InstanceProfile', 2);
   template.resourceCountIs('AWS::SSM::Document', 1);
   template.resourceCountIs('AWS::SSM::Association', 1);
   template.resourceCountIs('AWS::EFS::FileSystem', 1);
   template.resourceCountIs('AWS::CloudWatch::Alarm', 4);
+  template.resourceCountIs('AWS::SecretsManager::Secret', 1);
 });
 
 test('External security group is open', () => {

--- a/test/data/test_env.yaml
+++ b/test/data/test_env.yaml
@@ -254,6 +254,12 @@ tool:
               installers:
                 - adoptOpenJdkInstaller:
                     id: jdk-20.0.1+9
+      - name: openjdk-21
+        properties:
+          - installSource:
+              installers:
+                - adoptOpenJdkInstaller:
+                    id: jdk-21.0.1+12
   mavenGlobalConfig:
     globalSettingsProvider: standard
     settingsProvider: standard


### PR DESCRIPTION
### Description
Replace cdk-ec2-key-pair with CfnKeyPair construct to generate ec2 key pair. 
`aws-cdk-lib` provides `CfnKeyPair` construct to generate ec2 key-pairs. The private key is saved to AWS Systems Manager Parameter Store, using a parameter with the following name: /ec2/keypair/{key_pair_id}. See https://docs.aws.amazon.com/cdk/api/v2/docs/aws-cdk-lib.aws_ec2.CfnKeyPair.html for more details. 

### Issues Resolved
_List any issues this PR will resolve, e.g. Closes [...]._ 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
