### PR TITLE
Jenkins CLI CVE mitigation - using correct commit Id 

### DIFF
--- a/lib/compute/jenkins-main-node.ts
+++ b/lib/compute/jenkins-main-node.ts
@@ -268,7 +268,7 @@ export class JenkinsMainNode {
       // Jenkins CVE https://www.jenkins.io/security/advisory/2024-01-24/ mitigation 
       InitCommand.shellCommand('mkdir -p /var/lib/jenkins/init.groovy.d'),
       // eslint-disable-next-line max-len
-      InitCommand.shellCommand('sudo wget -P /var/lib/jenkins/init.groovy.d https://raw.githubusercontent.com/jenkinsci-cert/SECURITY-3314-3315/main/disable-cli.groovy'),
+      InitCommand.shellCommand('sudo curl -SL https://raw.githubusercontent.com/jenkinsci-cert/SECURITY-3314-3315/main/disable-cli.groovy -o /var/lib/jenkins/init.groovy.d/disable-cli.groovy'),
 
       // Configuration to proxy jenkins on :8080 -> :80
       InitFile.fromString('/etc/httpd/conf.d/jenkins.conf',

--- a/lib/compute/jenkins-main-node.ts
+++ b/lib/compute/jenkins-main-node.ts
@@ -265,6 +265,11 @@ export class JenkinsMainNode {
       + ' instance_id=`curl -f -H "X-aws-ec2-metadata-token: $TOKEN" http://169.254.169.254/latest/meta-data/instance-id` && echo $ami_id &&'
       + ` aws ec2 --region ${stackRegion} modify-instance-metadata-options --instance-id $instance_id --http-put-response-hop-limit 2`),
 
+      // Jenkins CVE https://www.jenkins.io/security/advisory/2024-01-24/ mitigation 
+      InitCommand.shellCommand('mkdir -p /var/lib/jenkins/init.groovy.d'),
+      // eslint-disable-next-line max-len
+      InitCommand.shellCommand('sudo wget -P /var/lib/jenkins/init.groovy.d https://raw.githubusercontent.com/jenkinsci-cert/SECURITY-3314-3315/main/disable-cli.groovy'),
+
       // Configuration to proxy jenkins on :8080 -> :80
       InitFile.fromString('/etc/httpd/conf.d/jenkins.conf',
         httpConfigProps.useSsl

--- a/lib/compute/jenkins-main-node.ts
+++ b/lib/compute/jenkins-main-node.ts
@@ -268,7 +268,7 @@ export class JenkinsMainNode {
       // Jenkins CVE https://www.jenkins.io/security/advisory/2024-01-24/ mitigation 
       InitCommand.shellCommand('mkdir -p /var/lib/jenkins/init.groovy.d'),
       // eslint-disable-next-line max-len
-      InitCommand.shellCommand('sudo curl -SL https://raw.githubusercontent.com/jenkinsci-cert/SECURITY-3314-3315/1363970ecc33a6b94620f2167d4a301fcf46bd36/disable-cli.groovy -o /var/lib/jenkins/init.groovy.d/disable-cli.groovy'),
+      InitCommand.shellCommand('sudo curl -SL https://raw.githubusercontent.com/jenkinsci-cert/SECURITY-3314-3315/55c15104fb70d6a2b46fd3f8ba7dec3913a4b1db/disable-cli.groovy -o /var/lib/jenkins/init.groovy.d/disable-cli.groovy'),
 
       // Configuration to proxy jenkins on :8080 -> :80
       InitFile.fromString('/etc/httpd/conf.d/jenkins.conf',

--- a/lib/compute/jenkins-main-node.ts
+++ b/lib/compute/jenkins-main-node.ts
@@ -268,7 +268,7 @@ export class JenkinsMainNode {
       // Jenkins CVE https://www.jenkins.io/security/advisory/2024-01-24/ mitigation 
       InitCommand.shellCommand('mkdir -p /var/lib/jenkins/init.groovy.d'),
       // eslint-disable-next-line max-len
-      InitCommand.shellCommand('sudo curl -SL https://raw.githubusercontent.com/jenkinsci-cert/SECURITY-3314-3315/main/disable-cli.groovy -o /var/lib/jenkins/init.groovy.d/disable-cli.groovy'),
+      InitCommand.shellCommand('sudo curl -SL https://raw.githubusercontent.com/jenkinsci-cert/SECURITY-3314-3315/1363970ecc33a6b94620f2167d4a301fcf46bd36/disable-cli.groovy -o /var/lib/jenkins/init.groovy.d/disable-cli.groovy'),
 
       // Configuration to proxy jenkins on :8080 -> :80
       InitFile.fromString('/etc/httpd/conf.d/jenkins.conf',

--- a/test/compute/jenkins-main-node.test.ts
+++ b/test/compute/jenkins-main-node.test.ts
@@ -26,7 +26,7 @@ describe('JenkinsMainNode Config Elements', () => {
 
   // THEN
   test('Config elements expected counts', async () => {
-    expect(configElements.filter((e) => e.elementType === 'COMMAND')).toHaveLength(20);
+    expect(configElements.filter((e) => e.elementType === 'COMMAND')).toHaveLength(22);
     expect(configElements.filter((e) => e.elementType === 'PACKAGE')).toHaveLength(9);
     expect(configElements.filter((e) => e.elementType === 'FILE')).toHaveLength(4);
   });


### PR DESCRIPTION
### Description
Using the repo commit Id instead of contributor's for stability 
https://github.com/jenkinsci-cert/SECURITY-3314-3315/commit/55c15104fb70d6a2b46fd3f8ba7dec3913a4b1db

### Issues Resolved
https://github.com/opensearch-project/opensearch-ci/issues/386

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
