### PR TITLE
Jenkins CLI CVE - using repo commit Id instead of contributors

### DIFF
--- a/lib/compute/jenkins-main-node.ts
+++ b/lib/compute/jenkins-main-node.ts
@@ -268,7 +268,7 @@ export class JenkinsMainNode {
       // Jenkins CVE https://www.jenkins.io/security/advisory/2024-01-24/ mitigation 
       InitCommand.shellCommand('mkdir -p /var/lib/jenkins/init.groovy.d'),
       // eslint-disable-next-line max-len
-      InitCommand.shellCommand('sudo curl -SL https://raw.githubusercontent.com/jenkinsci-cert/SECURITY-3314-3315/1363970ecc33a6b94620f2167d4a301fcf46bd36/disable-cli.groovy -o /var/lib/jenkins/init.groovy.d/disable-cli.groovy'),
+      InitCommand.shellCommand('sudo curl -SL https://raw.githubusercontent.com/jenkinsci-cert/SECURITY-3314-3315/55c15104fb70d6a2b46fd3f8ba7dec3913a4b1db/disable-cli.groovy -o /var/lib/jenkins/init.groovy.d/disable-cli.groovy'),
 
       // Configuration to proxy jenkins on :8080 -> :80
       InitFile.fromString('/etc/httpd/conf.d/jenkins.conf',


### PR DESCRIPTION
### Description
using repo commit Id instead of contributor's
https://github.com/jenkinsci-cert/SECURITY-3314-3315/commit/55c15104fb70d6a2b46fd3f8ba7dec3913a4b1db


### Issues Resolved
https://github.com/opensearch-project/opensearch-ci/issues/386

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
