### PR TITLE
Switch Main Node CPU threshold from 50 to 75

### DIFF
--- a/lib/monitoring/ci-alarms.ts
+++ b/lib/monitoring/ci-alarms.ts
@@ -31,7 +31,7 @@ export class JenkinsMonitoring {
       alarmDescription: 'Overall EC2 avg CPU Utilization',
       evaluationPeriods: 3,
       metric: cpuMetric,
-      threshold: 50,
+      threshold: 75,
       comparisonOperator: ComparisonOperator.GREATER_THAN_THRESHOLD,
     }));
 


### PR DESCRIPTION
### Description
Switch Main Node CPU threshold from 50 to 75

### Issues Resolved
Closes https://github.com/opensearch-project/opensearch-ci/issues/398

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
