### PR TITLE
adding X-Forwarded-for header in httpd access log

### DIFF
--- a/lib/compute/jenkins-main-node.ts
+++ b/lib/compute/jenkins-main-node.ts
@@ -275,6 +275,7 @@ export class JenkinsMainNode {
         httpConfigProps.useSsl
           // eslint-disable-next-line no-useless-escape
           ? `LogFormat "%{X-Forwarded-For}i %h %l %u %t \"%r\" %>s %b \"%{Referer}i\" \"%{User-Agent}i\"" combined
+          // eslint-disable-next-line no-useless-escape
             LogFormat "%h %l %u %t \"%r\" %>s %b" common
             <VirtualHost *:80>
                 ServerAdmin  webmaster@localhost

--- a/lib/compute/jenkins-main-node.ts
+++ b/lib/compute/jenkins-main-node.ts
@@ -273,7 +273,8 @@ export class JenkinsMainNode {
       // Configuration to proxy jenkins on :8080 -> :80
       InitFile.fromString('/etc/httpd/conf.d/jenkins.conf',
         httpConfigProps.useSsl
-          // eslint-disable-next-line no-useless-escape max-len
+          // eslint-disable-next-line no-useless-escape
+          // eslint-disable-next-line max-len
           ? `LogFormat "%{X-Forwarded-For}i %h %l %u %t \"%r\" %>s %b \"%{Referer}i\" \"%{User-Agent}i\"" combined & LogFormat "%h %l %u %t \"%r\" %>s %b" common
             <VirtualHost *:80>
                 ServerAdmin  webmaster@localhost

--- a/lib/compute/jenkins-main-node.ts
+++ b/lib/compute/jenkins-main-node.ts
@@ -273,7 +273,9 @@ export class JenkinsMainNode {
       // Configuration to proxy jenkins on :8080 -> :80
       InitFile.fromString('/etc/httpd/conf.d/jenkins.conf',
         httpConfigProps.useSsl
-          ? `<VirtualHost *:80>
+          ? `LogFormat "%{X-Forwarded-For}i %h %l %u %t \"%r\" %>s %b \"%{Referer}i\" \"%{User-Agent}i\"" combined
+            LogFormat "%h %l %u %t \"%r\" %>s %b" common
+            <VirtualHost *:80>
                 ServerAdmin  webmaster@localhost
                 Redirect permanent / https://replace_url.com/
             </VirtualHost>

--- a/lib/compute/jenkins-main-node.ts
+++ b/lib/compute/jenkins-main-node.ts
@@ -274,7 +274,7 @@ export class JenkinsMainNode {
       InitFile.fromString('/etc/httpd/conf.d/jenkins.conf',
         httpConfigProps.useSsl
           // eslint-disable-next-line no-useless-escape
-          ? `LogFormat "%{X-Forwarded-For}i %h %l %u %t \"%r\" %>s %b \"%{Referer}i\" \"%{User-Agent}i\"" combined & LogFormat "%h %l %u %t \"%r\" %>s %b" common
+          ? `LogFormat "%{X-Forwarded-For}i %h %l %u %t \"%r\" %>s %b \"%{Referer}i\" \"%{User-Agent}i\"" combined & LogFormat "%h %l %u %t \"%r\" %>s" common
             <VirtualHost *:80>
                 ServerAdmin  webmaster@localhost
                 Redirect permanent / https://replace_url.com/

--- a/lib/compute/jenkins-main-node.ts
+++ b/lib/compute/jenkins-main-node.ts
@@ -273,10 +273,8 @@ export class JenkinsMainNode {
       // Configuration to proxy jenkins on :8080 -> :80
       InitFile.fromString('/etc/httpd/conf.d/jenkins.conf',
         httpConfigProps.useSsl
-          // eslint-disable-next-line no-useless-escape
-          ? `LogFormat "%{X-Forwarded-For}i %h %l %u %t \"%r\" %>s %b \"%{Referer}i\" \"%{User-Agent}i\"" combined
-          // eslint-disable-next-line no-useless-escape
-            LogFormat "%h %l %u %t \"%r\" %>s %b" common
+          // eslint-disable-next-line no-useless-escape max-len
+          ? `LogFormat "%{X-Forwarded-For}i %h %l %u %t \"%r\" %>s %b \"%{Referer}i\" \"%{User-Agent}i\"" combined & LogFormat "%h %l %u %t \"%r\" %>s %b" common
             <VirtualHost *:80>
                 ServerAdmin  webmaster@localhost
                 Redirect permanent / https://replace_url.com/

--- a/lib/compute/jenkins-main-node.ts
+++ b/lib/compute/jenkins-main-node.ts
@@ -270,11 +270,12 @@ export class JenkinsMainNode {
       // eslint-disable-next-line max-len
       InitCommand.shellCommand('sudo curl -SL https://raw.githubusercontent.com/jenkinsci-cert/SECURITY-3314-3315/55c15104fb70d6a2b46fd3f8ba7dec3913a4b1db/disable-cli.groovy -o /var/lib/jenkins/init.groovy.d/disable-cli.groovy'),
 
+      // eslint-disable-next-line no-useless-escape
       // Configuration to proxy jenkins on :8080 -> :80
       InitFile.fromString('/etc/httpd/conf.d/jenkins.conf',
         httpConfigProps.useSsl
-          ? `LogFormat "%{X-Forwarded-For}i %h %l %u %t \'%r\' %>s %b \'%{Referer}i\' \'%{User-Agent}i\'" combined
-            LogFormat "%h %l %u %t \'%r\' %>s %b" common
+          ? `LogFormat "%{X-Forwarded-For}i %h %l %u %t \"%r\" %>s %b \"%{Referer}i\" \"%{User-Agent}i\"" combined
+            LogFormat "%h %l %u %t \"%r\" %>s %b" common
             <VirtualHost *:80>
                 ServerAdmin  webmaster@localhost
                 Redirect permanent / https://replace_url.com/

--- a/lib/compute/jenkins-main-node.ts
+++ b/lib/compute/jenkins-main-node.ts
@@ -273,8 +273,8 @@ export class JenkinsMainNode {
       // Configuration to proxy jenkins on :8080 -> :80
       InitFile.fromString('/etc/httpd/conf.d/jenkins.conf',
         httpConfigProps.useSsl
-          ? `LogFormat "%{X-Forwarded-For}i %h %l %u %t \"%r\" %>s %b \"%{Referer}i\" \"%{User-Agent}i\"" combined
-            LogFormat "%h %l %u %t \"%r\" %>s %b" common
+          ? `LogFormat "%{X-Forwarded-For}i %h %l %u %t \'%r\' %>s %b \'%{Referer}i\' \'%{User-Agent}i\'" combined
+            LogFormat "%h %l %u %t \'%r\' %>s %b" common
             <VirtualHost *:80>
                 ServerAdmin  webmaster@localhost
                 Redirect permanent / https://replace_url.com/

--- a/lib/compute/jenkins-main-node.ts
+++ b/lib/compute/jenkins-main-node.ts
@@ -274,7 +274,6 @@ export class JenkinsMainNode {
       InitFile.fromString('/etc/httpd/conf.d/jenkins.conf',
         httpConfigProps.useSsl
           // eslint-disable-next-line no-useless-escape
-          // eslint-disable-next-line max-len
           ? `LogFormat "%{X-Forwarded-For}i %h %l %u %t \"%r\" %>s %b \"%{Referer}i\" \"%{User-Agent}i\"" combined & LogFormat "%h %l %u %t \"%r\" %>s %b" common
             <VirtualHost *:80>
                 ServerAdmin  webmaster@localhost

--- a/lib/compute/jenkins-main-node.ts
+++ b/lib/compute/jenkins-main-node.ts
@@ -270,10 +270,10 @@ export class JenkinsMainNode {
       // eslint-disable-next-line max-len
       InitCommand.shellCommand('sudo curl -SL https://raw.githubusercontent.com/jenkinsci-cert/SECURITY-3314-3315/55c15104fb70d6a2b46fd3f8ba7dec3913a4b1db/disable-cli.groovy -o /var/lib/jenkins/init.groovy.d/disable-cli.groovy'),
 
-      // eslint-disable-next-line no-useless-escape
       // Configuration to proxy jenkins on :8080 -> :80
       InitFile.fromString('/etc/httpd/conf.d/jenkins.conf',
         httpConfigProps.useSsl
+          // eslint-disable-next-line no-useless-escape
           ? `LogFormat "%{X-Forwarded-For}i %h %l %u %t \"%r\" %>s %b \"%{Referer}i\" \"%{User-Agent}i\"" combined
             LogFormat "%h %l %u %t \"%r\" %>s %b" common
             <VirtualHost *:80>

--- a/lib/compute/jenkins-main-node.ts
+++ b/lib/compute/jenkins-main-node.ts
@@ -273,8 +273,8 @@ export class JenkinsMainNode {
       // Configuration to proxy jenkins on :8080 -> :80
       InitFile.fromString('/etc/httpd/conf.d/jenkins.conf',
         httpConfigProps.useSsl
-          // eslint-disable-next-line no-useless-escape
-          ? `LogFormat "%{X-Forwarded-For}i %h %l %u %t \"%r\" %>s %b \"%{Referer}i\" \"%{User-Agent}i\"" combined & LogFormat "%h %l %u %t \"%r\" %>s" common
+          // eslint-disable-next-line no-useless-escape,max-len
+          ? `LogFormat "%{X-Forwarded-For}i %h %l %u %t \"%r\" %>s %b \"%{Referer}i\" \"%{User-Agent}i\"" combined & LogFormat "%h %l %u %t \"%r\" %>s %b" common
             <VirtualHost *:80>
                 ServerAdmin  webmaster@localhost
                 Redirect permanent / https://replace_url.com/


### PR DESCRIPTION
### Description
Adding `X-Forwarded-For` header in httpd access log.

Reference: https://repost.aws/knowledge-center/elb-capture-client-ip-addresses

We apply this modification only on SSL-enabled sessions since all incoming internet traffic on the production environment is routed through SSL. Additionally, we make this adjustment in jenkins.conf instead of the default httpd.conf because we have created jenkins.conf, and it functions equivalently to httpd.conf.

### Issues Resolved
N/A

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
