### PR TITLE
Enable access logging for load balancer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,7 +11,7 @@ resources/jenkins.yaml
 # CDK asset staging directory
 .cdk.staging
 cdk.out
-
+cdk.context.json
 # excluding intellij Idea files
 *.iml
 .idea/

--- a/lib/ci-stack.ts
+++ b/lib/ci-stack.ts
@@ -199,6 +199,7 @@ export class CIStack extends Stack {
       targetInstance: mainJenkinsNode.mainNodeAsg,
       listenerCertificate,
       useSsl,
+      accessLogBucket: auditloggingS3Bucket.bucket,
     });
 
     const artifactBucket = new Bucket(this, 'BuildBucket');

--- a/lib/network/ci-external-load-balancer.ts
+++ b/lib/network/ci-external-load-balancer.ts
@@ -12,7 +12,8 @@ import { SecurityGroup, Vpc } from 'aws-cdk-lib/aws-ec2';
 import {
   ApplicationListener, ApplicationLoadBalancer, ApplicationProtocol, ApplicationTargetGroup, ListenerCertificate, Protocol, SslPolicy,
 } from 'aws-cdk-lib/aws-elasticloadbalancingv2';
-import { Bucket } from 'aws-cdk-lib/aws-s3';
+import { PolicyStatement, ServicePrincipal } from 'aws-cdk-lib/aws-iam';
+import { Bucket, BucketPolicy } from 'aws-cdk-lib/aws-s3';
 
 export interface JenkinsExternalLoadBalancerProps {
   readonly vpc: Vpc;
@@ -32,6 +33,7 @@ export class JenkinsExternalLoadBalancer {
 
   constructor(stack: Stack, props: JenkinsExternalLoadBalancerProps) {
     const accessPort = props.useSsl ? 443 : 80;
+    const accessLoggingPrefix = 'loadBalancerAccessLogs';
 
     // Using an ALB so it can be part of a security group rather than by whitelisting ip addresses
     this.loadBalancer = new ApplicationLoadBalancer(stack, 'JenkinsALB', {
@@ -65,7 +67,22 @@ export class JenkinsExternalLoadBalancer {
       },
     });
 
-    this.loadBalancer.logAccessLogs(props.accessLogBucket, 'loadBalancerAcessLogs');
+    this.loadBalancer.logAccessLogs(props.accessLogBucket, accessLoggingPrefix);
+
+    const bucketPolicy = new BucketPolicy(stack, 'ALBaccessLoggingBucketPolicyPErmission', {
+      bucket: props.accessLogBucket,
+    });
+
+    bucketPolicy.document.addStatements(
+      new PolicyStatement({
+        actions: ['s3:PutObject'],
+        principals: [
+          new ServicePrincipal('logdelivery.elasticloadbalancing.amazonaws.com'),
+        ],
+        resources: [`${props.accessLogBucket.bucketArn}/${accessLoggingPrefix}/*`],
+
+      }),
+    );
 
     new CfnOutput(stack, 'Jenkins External Load Balancer Dns', {
       value: this.loadBalancer.loadBalancerDnsName,

--- a/lib/network/ci-external-load-balancer.ts
+++ b/lib/network/ci-external-load-balancer.ts
@@ -7,12 +7,12 @@
  */
 
 import { CfnOutput, Stack } from 'aws-cdk-lib';
-import { Instance, SecurityGroup, Vpc } from 'aws-cdk-lib/aws-ec2';
+import { AutoScalingGroup } from 'aws-cdk-lib/aws-autoscaling';
+import { SecurityGroup, Vpc } from 'aws-cdk-lib/aws-ec2';
 import {
   ApplicationListener, ApplicationLoadBalancer, ApplicationProtocol, ApplicationTargetGroup, ListenerCertificate, Protocol, SslPolicy,
 } from 'aws-cdk-lib/aws-elasticloadbalancingv2';
-import { InstanceTarget } from 'aws-cdk-lib/aws-elasticloadbalancingv2-targets';
-import { AutoScalingGroup } from 'aws-cdk-lib/aws-autoscaling';
+import { Bucket } from 'aws-cdk-lib/aws-s3';
 
 export interface JenkinsExternalLoadBalancerProps {
   readonly vpc: Vpc;
@@ -20,6 +20,7 @@ export interface JenkinsExternalLoadBalancerProps {
   readonly targetInstance: AutoScalingGroup;
   readonly listenerCertificate: ListenerCertificate;
   readonly useSsl: boolean;
+  readonly accessLogBucket: Bucket;
 }
 
 export class JenkinsExternalLoadBalancer {
@@ -63,6 +64,8 @@ export class JenkinsExternalLoadBalancer {
         path: '/login',
       },
     });
+
+    this.loadBalancer.logAccessLogs(props.accessLogBucket, 'loadBalancerAcessLogs');
 
     new CfnOutput(stack, 'Jenkins External Load Balancer Dns', {
       value: this.loadBalancer.loadBalancerDnsName,

--- a/test/ci-stack.test.ts
+++ b/test/ci-stack.test.ts
@@ -21,6 +21,7 @@ test('CI Stack Basic Resources', () => {
   // WHEN
   const stack = new CIStack(app, 'TestStack', {
     dataRetention: true,
+    env: { account: 'test-account', region: 'us-east-1' },
   });
   const template = Template.fromStack(stack);
 
@@ -49,7 +50,7 @@ test('External security group is open', () => {
   });
 
   // WHEN
-  const stack = new CIStack(app, 'MyTestStack', {});
+  const stack = new CIStack(app, 'MyTestStack', { env: { account: 'test-account', region: 'us-east-1' } });
   const template = Template.fromStack(stack);
 
   // THEN
@@ -93,7 +94,11 @@ test('External security group is restricted', () => {
   });
 
   // WHEN
-  const stack = new CIStack(app, 'MyTestStack', { useSsl: true, restrictServerAccessTo: Peer.ipv4('10.0.0.0/24') });
+  const stack = new CIStack(app, 'MyTestStack', {
+    env: { account: 'test-account', region: 'us-east-1' },
+    useSsl: true,
+    restrictServerAccessTo: Peer.ipv4('10.0.0.0/24'),
+  });
   const template = Template.fromStack(stack);
 
   // THEN
@@ -135,7 +140,9 @@ test('MainNode', () => {
   });
 
   // WHEN
-  const stack = new CIStack(app, 'MyTestStack', {});
+  const stack = new CIStack(app, 'MyTestStack', {
+    env: { account: 'test-account', region: 'us-east-1' },
+  });
 
   // THEN
   Template.fromStack(stack).hasResourceProperties('AWS::AutoScaling::LaunchConfiguration', {
@@ -165,7 +172,9 @@ test('LoadBalancer', () => {
   });
 
   // WHEN
-  const stack = new CIStack(app, 'MyTestStack', {});
+  const stack = new CIStack(app, 'MyTestStack', {
+    env: { account: 'test-account', region: 'us-east-1' },
+  });
 
   // THEN
   Template.fromStack(stack).hasResourceProperties('AWS::ElasticLoadBalancingV2::LoadBalancer', {
@@ -188,7 +197,9 @@ test('CloudwatchCpuAlarm', () => {
   });
 
   // WHEN
-  const stack = new CIStack(app, 'MyTestStack', {});
+  const stack = new CIStack(app, 'MyTestStack', {
+    env: { account: 'test-account', region: 'us-east-1' },
+  });
 
   // THEN
   Template.fromStack(stack).hasResourceProperties('AWS::CloudWatch::Alarm', {
@@ -205,7 +216,9 @@ test('CloudwatchMemoryAlarm', () => {
   });
 
   // WHEN
-  const stack = new CIStack(app, 'MyTestStack', {});
+  const stack = new CIStack(app, 'MyTestStack', {
+    env: { account: 'test-account', region: 'us-east-1' },
+  });
 
   // THEN
   Template.fromStack(stack).hasResourceProperties('AWS::CloudWatch::Alarm', {


### PR DESCRIPTION
### Description
Adding one more layer of monitoring for security purpose by enabling access logging on load balancer. The logs will be written to the audit bucket within `loadBalancerAccessLogs` folder

### Issues Resolved
_List any issues this PR will resolve, e.g. Closes [...]._ 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
