### PR TITLE
Add to existing policy instead of creating new one

### DIFF
--- a/lib/network/ci-external-load-balancer.ts
+++ b/lib/network/ci-external-load-balancer.ts
@@ -13,7 +13,7 @@ import {
   ApplicationListener, ApplicationLoadBalancer, ApplicationProtocol, ApplicationTargetGroup, ListenerCertificate, Protocol, SslPolicy,
 } from 'aws-cdk-lib/aws-elasticloadbalancingv2';
 import { PolicyStatement, ServicePrincipal } from 'aws-cdk-lib/aws-iam';
-import { Bucket, BucketPolicy } from 'aws-cdk-lib/aws-s3';
+import { Bucket } from 'aws-cdk-lib/aws-s3';
 
 export interface JenkinsExternalLoadBalancerProps {
   readonly vpc: Vpc;
@@ -69,11 +69,7 @@ export class JenkinsExternalLoadBalancer {
 
     this.loadBalancer.logAccessLogs(props.accessLogBucket, accessLoggingPrefix);
 
-    const bucketPolicy = new BucketPolicy(stack, 'ALBaccessLoggingBucketPolicyPErmission', {
-      bucket: props.accessLogBucket,
-    });
-
-    bucketPolicy.document.addStatements(
+    props.accessLogBucket.addToResourcePolicy(
       new PolicyStatement({
         actions: ['s3:PutObject'],
         principals: [

--- a/test/ci-stack.test.ts
+++ b/test/ci-stack.test.ts
@@ -267,6 +267,84 @@ test('LoadBalancer Access Logging', () => {
     PolicyDocument: {
       Statement: [
         {
+          Action: [
+            's3:PutObject',
+            's3:PutObjectLegalHold',
+            's3:PutObjectRetention',
+            's3:PutObjectTagging',
+            's3:PutObjectVersionTagging',
+            's3:Abort*',
+          ],
+          Effect: 'Allow',
+          Principal: {
+            AWS: {
+              'Fn::Join': [
+                '',
+                [
+                  'arn:',
+                  {
+                    Ref: 'AWS::Partition',
+                  },
+                  ':iam::127311923021:root',
+                ],
+              ],
+            },
+          },
+          Resource: {
+            'Fn::Join': [
+              '',
+              [
+                {
+                  'Fn::GetAtt': [
+                    'jenkinsAuditBucket110D3080',
+                    'Arn',
+                  ],
+                },
+                '/loadBalancerAccessLogs/AWSLogs/test-account/*',
+              ],
+            ],
+          },
+        },
+        {
+          Action: 's3:PutObject',
+          Condition: {
+            StringEquals: {
+              's3:x-amz-acl': 'bucket-owner-full-control',
+            },
+          },
+          Effect: 'Allow',
+          Principal: {
+            Service: 'delivery.logs.amazonaws.com',
+          },
+          Resource: {
+            'Fn::Join': [
+              '',
+              [
+                {
+                  'Fn::GetAtt': [
+                    'jenkinsAuditBucket110D3080',
+                    'Arn',
+                  ],
+                },
+                '/loadBalancerAccessLogs/AWSLogs/test-account/*',
+              ],
+            ],
+          },
+        },
+        {
+          Action: 's3:GetBucketAcl',
+          Effect: 'Allow',
+          Principal: {
+            Service: 'delivery.logs.amazonaws.com',
+          },
+          Resource: {
+            'Fn::GetAtt': [
+              'jenkinsAuditBucket110D3080',
+              'Arn',
+            ],
+          },
+        },
+        {
           Action: 's3:PutObject',
           Effect: 'Allow',
           Principal: {


### PR DESCRIPTION
### Description
The inline bucket policy cannot be recreated or added. It can only be modified as per documentation. Since users might have already existing bucket, this change prevents from breaking  

### Issues Resolved
_List any issues this PR will resolve, e.g. Closes [...]._ 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
