### PR TITLE
Adding X-Forwarded-For header in httpd access_log

### DIFF
--- a/lib/compute/jenkins-main-node.ts
+++ b/lib/compute/jenkins-main-node.ts
@@ -273,7 +273,9 @@ export class JenkinsMainNode {
       // Configuration to proxy jenkins on :8080 -> :80
       InitFile.fromString('/etc/httpd/conf.d/jenkins.conf',
         httpConfigProps.useSsl
-          ? `<VirtualHost *:80>
+          // eslint-disable-next-line no-useless-escape,max-len
+          ? `LogFormat "%{X-Forwarded-For}i %h %l %u %t \"%r\" %>s %b \"%{Referer}i\" \"%{User-Agent}i\"" combined
+            <VirtualHost *:80>
                 ServerAdmin  webmaster@localhost
                 Redirect permanent / https://replace_url.com/
             </VirtualHost>


### PR DESCRIPTION
### Description
Adding X-Forwarded-For header in httpd access_log

Ref: https://repost.aws/knowledge-center/elb-capture-client-ip-addresses
We want to enable the original source IP to be shown in httpd access_log.
The updated LogFormat can be added in the default` httpd.conf `or any configiuration that will be taken by the httpd.
In our case, the `jenkins.conf`.

Also, we only need to add customed `combined` LogFormat because the it is the enabled log format used in default httpd.conf.

here is the snippet of default httpd.conf where defines which log format is applied to access_log
```
    #
    # The location and format of the access logfile (Common Logfile Format).
    # If you do not define any access logfiles within a <VirtualHost>
    # container, they will be logged here.  Contrariwise, if you *do*
    # define per-<VirtualHost> access logfiles, transactions will be
    # logged therein and *not* in this file.
    #
    #CustomLog "logs/access_log" common

    #
    # If you prefer a logfile with access, agent, and referer information
    # (Combined Logfile Format) you can use the following directive.
    #
    CustomLog "logs/access_log" combined
</IfModule>
```


sample output in access_log after the implementation:
```
2.21.198.66 10.0.19.198 - - [20/Mar/2024:05:16:31 +0000] "GET / HTTP/1.1" 200 3958 "-" "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/122.0.0.0 Safari/537.36"
72.21.198.66 10.0.19.198 - - [20/Mar/2024:05:16:34 +0000] "GET /static/2b4b35c5/jsbundles/styles.css HTTP/1.1" 200 29906 "https://reverseproxyalb-2014717995.us-east-1.elb.amazonaws.com/" "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/122.0.0.0 Safari/537.36"
```


### Issues Resolved
N/A

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
