### PR TITLE
Add WAF rules to protect Jenkins endpoint

### DIFF
--- a/lib/ci-stack.ts
+++ b/lib/ci-stack.ts
@@ -25,6 +25,7 @@ import { RunAdditionalCommands } from './compute/run-additional-commands';
 import { JenkinsMonitoring } from './monitoring/ci-alarms';
 import { JenkinsExternalLoadBalancer } from './network/ci-external-load-balancer';
 import { JenkinsSecurityGroups } from './security/ci-security-groups';
+import { JenkinsWAF } from './security/waf';
 
 export interface CIStackProps extends StackProps {
   /** Should the Jenkins use https  */
@@ -200,6 +201,10 @@ export class CIStack extends Stack {
       listenerCertificate,
       useSsl,
       accessLogBucket: auditloggingS3Bucket.bucket,
+    });
+
+    const waf = new JenkinsWAF(this, {
+      loadBalancer: externalLoadBalancer.loadBalancer,
     });
 
     const artifactBucket = new Bucket(this, 'BuildBucket');

--- a/lib/security/waf.ts
+++ b/lib/security/waf.ts
@@ -1,0 +1,120 @@
+import { Stack, StackProps } from 'aws-cdk-lib';
+import { ApplicationLoadBalancer } from 'aws-cdk-lib/aws-elasticloadbalancingv2';
+import { CfnWebACL, CfnWebACLAssociation, CfnWebACLAssociationProps } from 'aws-cdk-lib/aws-wafv2';
+import { Construct } from 'constructs';
+
+interface WafRule {
+    name: string;
+    rule: CfnWebACL.RuleProperty;
+}
+
+const awsManagedRules: WafRule[] = [
+  // AWS IP Reputation list includes known malicious actors/bots and is regularly updated
+  {
+    name: 'AWS-AWSManagedRulesAmazonIpReputationList',
+    rule: {
+      name: 'AWS-AWSManagedRulesAmazonIpReputationList',
+      priority: 0,
+      statement: {
+        managedRuleGroupStatement: {
+          vendorName: 'AWS',
+          name: 'AWSManagedRulesAmazonIpReputationList',
+        },
+      },
+      overrideAction: {
+        none: {},
+      },
+      visibilityConfig: {
+        sampledRequestsEnabled: true,
+        cloudWatchMetricsEnabled: true,
+        metricName: 'AWSManagedRulesAmazonIpReputationList',
+      },
+    },
+  },
+  // Blocks common SQL Injection
+  {
+    name: 'AWS-AWSManagedRulesSQLiRuleSet',
+    rule: {
+      name: 'AWS-AWSManagedRulesSQLiRuleSet',
+      priority: 1,
+      statement: {
+        managedRuleGroupStatement: {
+          vendorName: 'AWS',
+          name: 'AWSManagedRulesSQLiRuleSet',
+          excludedRules: [],
+        },
+      },
+      visibilityConfig: {
+        sampledRequestsEnabled: true,
+        cloudWatchMetricsEnabled: true,
+        metricName: 'AWS-AWSManagedRulesSQLiRuleSet',
+      },
+      overrideAction: {
+        none: {},
+      },
+    },
+  },
+  // Block request patterns associated with the exploitation of vulnerabilities specific to WordPress sites.
+  {
+    name: 'AWS-AWSManagedRulesWordPressRuleSet',
+    rule: {
+      name: 'AWS-AWSManagedRulesWordPressRuleSet',
+      priority: 2,
+      visibilityConfig: {
+        sampledRequestsEnabled: true,
+        cloudWatchMetricsEnabled: true,
+        metricName: 'AWS-AWSManagedRulesWordPressRuleSet',
+      },
+      overrideAction: {
+        none: {},
+      },
+      statement: {
+        managedRuleGroupStatement: {
+          vendorName: 'AWS',
+          name: 'AWSManagedRulesWordPressRuleSet',
+          excludedRules: [],
+        },
+      },
+    },
+  },
+];
+
+export class WAF extends CfnWebACL {
+  constructor(scope: Construct, id: string) {
+    super(scope, id, {
+      defaultAction: { allow: {} },
+      visibilityConfig: {
+        cloudWatchMetricsEnabled: true,
+        metricName: 'jenkins-WAF',
+        sampledRequestsEnabled: false,
+      },
+      scope: 'REGIONAL',
+      name: 'jenkins-WAF',
+      rules: awsManagedRules.map((wafRule) => wafRule.rule),
+    });
+  }
+}
+
+export class WebACLAssociation extends CfnWebACLAssociation {
+  constructor(scope: Construct, id: string, props: CfnWebACLAssociationProps) {
+    super(scope, id, {
+      resourceArn: props.resourceArn,
+      webAclArn: props.webAclArn,
+    });
+  }
+}
+
+export interface WafProps extends StackProps{
+    loadBalancer: ApplicationLoadBalancer
+}
+
+export class JenkinsWAF {
+  constructor(stack: Stack, props: WafProps) {
+    const waf = new WAF(stack, 'WAFv2');
+    // Create an association with the alb
+    new WebACLAssociation(stack, 'wafALBassociation', {
+      resourceArn: props.loadBalancer.loadBalancerArn,
+      webAclArn: waf.attrArn,
+    });
+  }
+}

--- a/lib/security/waf.ts
+++ b/lib/security/waf.ts
@@ -86,7 +86,7 @@ export class WAF extends CfnWebACL {
       visibilityConfig: {
         cloudWatchMetricsEnabled: true,
         metricName: 'jenkins-WAF',
-        sampledRequestsEnabled: false,
+        sampledRequestsEnabled: true,
       },
       scope: 'REGIONAL',
       name: 'jenkins-WAF',

--- a/test/ci-stack.test.ts
+++ b/test/ci-stack.test.ts
@@ -370,3 +370,114 @@ test('LoadBalancer Access Logging', () => {
     },
   });
 });
+
+test('WAF rules', () => {
+  const app = new App({
+    context: {
+      useSsl: 'false', runWithOidc: 'false', serverAccessType: 'ipv4', restrictServerAccessTo: '10.10.10.10/32',
+    },
+  });
+
+  // WHEN
+  const stack = new CIStack(app, 'MyTestStack', {
+    env: { account: 'test-account', region: 'us-east-1' },
+  });
+
+  // THEN
+  Template.fromStack(stack).hasResourceProperties('AWS::WAFv2::WebACL', {
+    DefaultAction: {
+      Allow: {},
+    },
+    Scope: 'REGIONAL',
+    VisibilityConfig: {
+      CloudWatchMetricsEnabled: true,
+      MetricName: 'jenkins-WAF',
+      SampledRequestsEnabled: false,
+    },
+    Name: 'jenkins-WAF',
+    Rules: [
+      {
+        Name: 'AWS-AWSManagedRulesAmazonIpReputationList',
+        OverrideAction: {
+          None: {},
+        },
+        Priority: 0,
+        Statement: {
+          ManagedRuleGroupStatement: {
+            Name: 'AWSManagedRulesAmazonIpReputationList',
+            VendorName: 'AWS',
+          },
+        },
+        VisibilityConfig: {
+          CloudWatchMetricsEnabled: true,
+          MetricName: 'AWSManagedRulesAmazonIpReputationList',
+          SampledRequestsEnabled: true,
+        },
+      },
+      {
+        Name: 'AWS-AWSManagedRulesSQLiRuleSet',
+        OverrideAction: {
+          None: {},
+        },
+        Priority: 1,
+        Statement: {
+          ManagedRuleGroupStatement: {
+            ExcludedRules: [],
+            Name: 'AWSManagedRulesSQLiRuleSet',
+            VendorName: 'AWS',
+          },
+        },
+        VisibilityConfig: {
+          CloudWatchMetricsEnabled: true,
+          MetricName: 'AWS-AWSManagedRulesSQLiRuleSet',
+          SampledRequestsEnabled: true,
+        },
+      },
+      {
+        Name: 'AWS-AWSManagedRulesWordPressRuleSet',
+        OverrideAction: {
+          None: {},
+        },
+        Priority: 2,
+        Statement: {
+          ManagedRuleGroupStatement: {
+            ExcludedRules: [],
+            Name: 'AWSManagedRulesWordPressRuleSet',
+            VendorName: 'AWS',
+          },
+        },
+        VisibilityConfig: {
+          CloudWatchMetricsEnabled: true,
+          MetricName: 'AWS-AWSManagedRulesWordPressRuleSet',
+          SampledRequestsEnabled: true,
+        },
+      },
+    ],
+  });
+});
+
+test('Test WAF association with ALB', () => {
+  const app = new App({
+    context: {
+      useSsl: 'false', runWithOidc: 'false', serverAccessType: 'ipv4', restrictServerAccessTo: '10.10.10.10/32',
+    },
+  });
+
+  // WHEN
+  const stack = new CIStack(app, 'MyTestStack', {
+    env: { account: 'test-account', region: 'us-east-1' },
+  });
+
+  // THEN
+  Template.fromStack(stack).hasResourceProperties('AWS::WAFv2::WebACLAssociation', {
+    ResourceArn: {
+      Ref: 'JenkinsALB9F3D5428',
+    },
+    WebACLArn: {
+      'Fn::GetAtt': [
+        'WAFv2',
+        'Arn',
+      ],
+    },
+  });
+});

--- a/test/ci-stack.test.ts
+++ b/test/ci-stack.test.ts
@@ -374,7 +374,7 @@ test('LoadBalancer Access Logging', () => {
 test('WAF rules', () => {
   const app = new App({
     context: {
-      useSsl: 'false', runWithOidc: 'false', serverAccessType: 'ipv4', restrictServerAccessTo: '10.10.10.10/32',
+      useSsl: 'false', runWithOidc: 'false', serverAccessType: 'ipv4', restrictServerAccessTo: '0.0.0.0/0',
     },
   });
 
@@ -459,7 +459,7 @@ test('WAF rules', () => {
 test('Test WAF association with ALB', () => {
   const app = new App({
     context: {
-      useSsl: 'false', runWithOidc: 'false', serverAccessType: 'ipv4', restrictServerAccessTo: '10.10.10.10/32',
+      useSsl: 'false', runWithOidc: 'false', serverAccessType: 'ipv4', restrictServerAccessTo: '0.0.0.0/0',
     },
   });
 

--- a/test/ci-stack.test.ts
+++ b/test/ci-stack.test.ts
@@ -392,7 +392,7 @@ test('WAF rules', () => {
     VisibilityConfig: {
       CloudWatchMetricsEnabled: true,
       MetricName: 'jenkins-WAF',
-      SampledRequestsEnabled: false,
+      SampledRequestsEnabled: true,
     },
     Name: 'jenkins-WAF',
     Rules: [


### PR DESCRIPTION
### Description
Adding one more layer of security by adding WAF rules and associating with the load balancer. This prevents DDoS attack when endpoint is public.

### Issues Resolved
_List any issues this PR will resolve, e.g. Closes [...]._ 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
