### PR TITLE
Replace default curl 7.68 on Ubuntu 20.04 with 7.75+ version to support aws-sigv4

### DIFF
--- a/packer/scripts/ubuntu2004/ubuntu2004-agent-setups.sh
+++ b/packer/scripts/ubuntu2004/ubuntu2004-agent-setups.sh
@@ -16,6 +16,14 @@ sudo apt-get update -y && sudo apt-get install -y binfmt-support qemu qemu-user 
 sudo apt-get install -y docker docker.io docker-compose ntp curl git gnupg2 tar zip unzip jq
 sudo apt-get install -y build-essential
 
+# Replace default curl 7.68 on Ubuntu 20.04 with 7.75+ version to support aws-sigv4
+# https://github.com/curl/curl/commit/08e8455dddc5e48e58a12ade3815c01ae3da3b64
+# https://curl.se/changes.html#7_75_0
+sudo curl -SL https://github.com/stunnel/static-curl/releases/download/8.6.0-1/curl-linux-`uname -m`-8.6.0.tar.xz -o curl.tar.xz
+sudo tar -xvf curl.tar.xz
+mv -v curl /usr/local/bin/curl
+rm -v curl.tar.xz
+
 sudo systemctl restart ntp && sudo systemctl enable ntp && sudo systemctl status ntp
 sudo systemctl restart docker && sudo systemctl enable docker && sudo systemctl status docker
 sudo usermod -a -G docker `whoami`


### PR DESCRIPTION


### Description
Replace default curl 7.68 on Ubuntu 20.04 with 7.75+ version to support aws-sigv4

### Issues Resolved
opensearch-project/opensearch-build#4469

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
