### PR TITLE
Replace c54xlarge with m54xlarge for Windows Docker Host

### DIFF
--- a/packer/jenkins-agent-win2019-x64.json
+++ b/packer/jenkins-agent-win2019-x64.json
@@ -17,7 +17,7 @@
       "encrypt_boot":"false",
       "region":"{{user `build-region`}}",
       "ami_regions":"{{user `aws_ami_region`}}",
-      "instance_type":"c5.4xlarge",
+      "instance_type":"m5.4xlarge",
       "ami_name":"{{user `name-base`}}-{{user `build-time`}}",
       "vpc_id":"{{user `build-vpc`}}",
       "subnet_id":"{{user `build-subnet`}}",
@@ -68,7 +68,7 @@
     {
       "type":"powershell",
       "inline": [
-        "C:\\Users\\Administrator\\jenkins\\winrm_max_memory.ps1 30"
+        "C:\\Users\\Administrator\\jenkins\\winrm_max_memory.ps1 62"
       ]
     },
     {

--- a/packer/scripts/windows/winrm_max_memory.ps1
+++ b/packer/scripts/windows/winrm_max_memory.ps1
@@ -6,7 +6,7 @@
 # compatible open source license.
 
 echo "The max amount of the winrm memory is not the same on different instance type and might cause the server unresponsive upon startup"
-echo "The only examples we have now is C54xlarge can have 30/32GB on WINRM, C524large 190/192GB, M58xlarge 110/128GB without failures"
+echo "The only examples we have now is C54xlarge can have 30/32GB on WINRM, C524large 190/192GB, M54xlarge 62/64GB, M58xlarge 110/128GB without failures"
 
 $memorygb = [int]$args[0]
 $memorygb


### PR DESCRIPTION
### Description
Replace c54xlarge with m54xlarge for Windows Docker Host

### Issues Resolved
https://github.com/opensearch-project/opensearch-ci/issues/412

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
