### PR TITLE
[Upgrade] Creating new AMIs with default JDK21

### DIFF
--- a/packer/jenkins-agent-al2-arm64.json
+++ b/packer/jenkins-agent-al2-arm64.json
@@ -1,6 +1,6 @@
 {
   "variables": {
-    "name-base":"Jenkins-Agent-AL2-ARM64",
+    "name-base":"Jenkins-Agent-AL2-ARM64-JDK21",
     "os-version": "AL2",
     "build-region":"us-east-1",
     "build-vpc":"vpc-<>",

--- a/packer/jenkins-agent-al2-x64.json
+++ b/packer/jenkins-agent-al2-x64.json
@@ -1,6 +1,6 @@
 {
   "variables": {
-    "name-base":"Jenkins-Agent-AL2-X64",
+    "name-base":"Jenkins-Agent-AL2-X64-JDK21",
     "os-version": "AL2",
     "build-region":"us-east-1",
     "build-vpc":"vpc-<>",

--- a/packer/jenkins-agent-al2023-arm64.json
+++ b/packer/jenkins-agent-al2023-arm64.json
@@ -1,6 +1,6 @@
 {
   "variables": {
-    "name-base":"Jenkins-Agent-AL2023-ARM64",
+    "name-base":"Jenkins-Agent-AL2023-ARM64-JDK21",
     "os-version": "AL2023",
     "build-region":"us-east-1",
     "build-vpc":"vpc-<>",

--- a/packer/jenkins-agent-al2023-x64.json
+++ b/packer/jenkins-agent-al2023-x64.json
@@ -1,6 +1,6 @@
 {
   "variables": {
-    "name-base":"Jenkins-Agent-AL2023-X64",
+    "name-base":"Jenkins-Agent-AL2023-X64-JDK21",
     "os-version": "AL2023",
     "build-region":"us-east-1",
     "build-vpc":"vpc-<>",

--- a/packer/jenkins-agent-macos12-x64.json
+++ b/packer/jenkins-agent-macos12-x64.json
@@ -1,6 +1,6 @@
 {
   "variables":{
-    "ami_name":"Jenkins-Agent-MacOS-X64-Mac1Metal",
+    "ami_name":"Jenkins-Agent-MacOS-X64-Mac1Metal-JDK21",
     "os_version": "12.4",
     "os_architecture": "x86_64_mac",
     "build-region":"us-east-1",

--- a/packer/jenkins-agent-ubuntu2004-x64.json
+++ b/packer/jenkins-agent-ubuntu2004-x64.json
@@ -1,6 +1,6 @@
 {
   "variables": {
-    "name-base":"Jenkins-Agent-Ubuntu2004-X64",
+    "name-base":"Jenkins-Agent-Ubuntu2004-X64-JDK21",
     "os-version": "Ubuntu2004",
     "build-region":"us-east-1",
     "build-vpc":"vpc-<>",

--- a/packer/jenkins-agent-win2019-x64-gradle-check.json
+++ b/packer/jenkins-agent-win2019-x64-gradle-check.json
@@ -1,6 +1,6 @@
 {
   "variables": {
-    "name-base":"Jenkins-Agent-Windows2019-X64-Gradle-Check",
+    "name-base":"Jenkins-Agent-Windows2019-X64-Gradle-Check-JDK21",
     "os-version": "Windows2019",
     "build-region":"us-east-1",
     "build-vpc":"vpc-<>",

--- a/packer/jenkins-agent-win2019-x64.json
+++ b/packer/jenkins-agent-win2019-x64.json
@@ -1,6 +1,6 @@
 {
   "variables": {
-    "name-base":"Jenkins-Agent-Windows2019-X64",
+    "name-base":"Jenkins-Agent-Windows2019-X64-JDK21",
     "os-version": "Windows2019",
     "build-region":"us-east-1",
     "build-vpc":"vpc-<>",

--- a/packer/scripts/al2/al2-agent-setups.sh
+++ b/packer/scripts/al2/al2-agent-setups.sh
@@ -19,7 +19,19 @@ sudo rm -rf /var/cache/yum /var/lib/yum/history
 sudo yum repolist
 sudo yum update --skip-broken --exclude=openssh* --exclude=docker* -y
 
-sudo amazon-linux-extras install java-openjdk11 -y
+# Create the adoptium.repo file
+sudo tee /etc/yum.repos.d/adoptium.repo <<EOF
+[Adoptium]
+name=Adoptium
+baseurl=https://packages.adoptium.net/artifactory/rpm/amazonlinux/\$releasever/\$basearch
+enabled=1
+gpgcheck=1
+gpgkey=https://packages.adoptium.net/artifactory/api/gpg/key/public
+EOF
+
+# Install Temurin JDK 21
+sudo yum install -y temurin-21-jdk
+
 sudo yum install -y which curl git gnupg2 tar net-tools procps-ng python3 python3-devel python3-pip zip unzip jq
 sudo yum install -y docker ntp
 sudo yum groupinstall -y "Development Tools"

--- a/packer/scripts/al2023/al2023-agent-setups.sh
+++ b/packer/scripts/al2023/al2023-agent-setups.sh
@@ -19,7 +19,7 @@ sudo rm -rf /var/cache/dnf
 sudo dnf repolist
 sudo dnf update --skip-broken --exclude=openssh* --exclude=docker* -y
 
-sudo dnf install -y java-11-amazon-corretto java-11-amazon-corretto-devel
+sudo dnf install -y java-21-amazon-corretto java-21-amazon-corretto-devel
 sudo dnf install -y which git tar net-tools procps-ng python3 python3-devel python3-pip zip unzip jq
 sudo dnf install -y docker
 sudo dnf groupinstall -y "Development Tools"

--- a/packer/scripts/macos/macos-agentsetup.sh
+++ b/packer/scripts/macos/macos-agentsetup.sh
@@ -36,8 +36,8 @@ for version_info in "${jdk_versions[@]}"; do
     /usr/local/bin/update-alternatives --install /usr/local/bin/java java "/opt/java/openjdk-${version_num}/Contents/Home/bin/java" ${version_priority}
 done
 
-## Set default Java to 11
-/usr/local/bin/update-alternatives --set java "$(/usr/local/bin/update-alternatives --list java | grep openjdk-11)"
+## Set default Java to 21
+/usr/local/bin/update-alternatives --set java "$(/usr/local/bin/update-alternatives --list java | grep openjdk-21)"
 
 ## Install MacPorts and python39
 /usr/local/bin/wget https://github.com/macports/macports-base/releases/download/v2.7.2/MacPorts-2.7.2.tar.gz

--- a/packer/scripts/ubuntu2004/ubuntu2004-agent-setups.sh
+++ b/packer/scripts/ubuntu2004/ubuntu2004-agent-setups.sh
@@ -52,9 +52,9 @@ sudo chown root:root -R adoptopenjdk-14-amd64
 sudo mv adoptopenjdk-14-amd64 /usr/lib/jvm/
 sudo update-alternatives --install "/usr/bin/javac" "javac" "/usr/lib/jvm/adoptopenjdk-14-amd64/bin/javac" 1111
 sudo update-alternatives --install "/usr/bin/java" "java" "/usr/lib/jvm/adoptopenjdk-14-amd64/bin/java" 1111
-# Reset to JDK11 so Jenkins can bootstrap it
-sudo update-alternatives --set "java" "/usr/lib/jvm/temurin-11-jdk-amd64/bin/java"
-sudo update-alternatives --set "javac" "/usr/lib/jvm/temurin-11-jdk-amd64/bin/javac"
+# Reset to JDK21 so Jenkins can bootstrap it
+sudo update-alternatives --set "java" "/usr/lib/jvm/temurin-21-jdk-amd64/bin/java"
+sudo update-alternatives --set "javac" "/usr/lib/jvm/temurin-21-jdk-amd64/bin/javac"
 java -version
 
 sudo apt-mark hold docker docker.io openssh-server temurin-8-jdk temurin-11-jdk temurin-17-jdk temurin-19-jdk temurin-20-jdk temurin-21-jdk

--- a/packer/scripts/windows/legacy/scoop-install-commons.ps1
+++ b/packer/scripts/windows/legacy/scoop-install-commons.ps1
@@ -86,8 +86,8 @@ Foreach ($jdkVersion in $jdkVersionList)
     [System.Environment]::SetEnvironmentVariable($jdkArray[1], "$JAVA_HOME_TEMP", [System.EnvironmentVariableTarget]::User)
     java -version
 }
-# Need to reset to jdk11 for Jenkins Agent to start
-scoop reset temurin11-jdk
+# Need to reset to jdk21 for Jenkins Agent to start
+scoop reset openjdk21
 $JAVA_HOME_TEMP = [System.Environment]::GetEnvironmentVariable("JAVA_HOME", [System.EnvironmentVariableTarget]::User).replace("\", "/")
 $JAVA_HOME_TEMP
 [System.Environment]::SetEnvironmentVariable('JAVA_HOME', "$JAVA_HOME_TEMP", [System.EnvironmentVariableTarget]::User)

--- a/packer/scripts/windows/scoop-install-commons-docker-support.ps1
+++ b/packer/scripts/windows/scoop-install-commons-docker-support.ps1
@@ -47,7 +47,7 @@ scoop bucket add extras
 scoop bucket add github-gh https://github.com/cli/scoop-gh.git
 
 # Install jdk
-$jdkVersionList = "temurin11-jdk JAVA11_HOME"
+$jdkVersionList = "temurin21-jdk JAVA21_HOME"
 Foreach ($jdkVersion in $jdkVersionList)
 {
     $jdkVersion


### PR DESCRIPTION
### Description
Creating new AMIs with default JDK21 on each agent

### Issues Resolved
N/A

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
