### PR TITLE
Applying necessary changes for Jenkins 2.440.2 upgrade

### DIFF
--- a/lib/compute/agent-node-config.ts
+++ b/lib/compute/agent-node-config.ts
@@ -157,7 +157,7 @@ export class AgentNodeConfig {
 
     const agentNodeYamlConfig = [{
       amazonEC2: {
-        cloudName: 'Amazon_ec2_cloud',
+        name: 'Amazon_ec2_cloud',
         region: this.STACKREGION,
         sshKeysCredentialsId: this.SSHEC2KeySecretId,
         templates: configTemplates,

--- a/resources/baseJenkins.yaml
+++ b/resources/baseJenkins.yaml
@@ -54,6 +54,9 @@ globalCredentialsConfiguration:
   configuration:
     providerFilter: "none"
     typeFilter: "none"
+appearance:
+  loginTheme:
+    useDefaultTheme: true
 security:
   apiToken:
     creationOfLegacyTokenEnabled: false
@@ -125,7 +128,7 @@ unclassified:
     apiRateLimitChecker: ThrottleForNormalize
   gitHubPluginConfig:
     hookUrl: "http://localhost:8080/github-webhook/"
-  gitSCM:
+  scmGit:
     addGitTagAction: false
     allowSecondFetch: false
     createAccountBasedOnEmail: false
@@ -139,14 +142,10 @@ unclassified:
     storage: "file"
   location:
     adminAddress: "address not configured yet <nobody@nowhere>"
-  login-theme-plugin:
-    useDefaultTheme: true
   mailer:
     charset: "UTF-8"
     useSsl: false
     useTls: false
-  pluginImpl:
-    enableCredentialsFromNode: false
   pollSCM:
     pollingThreadCount: 10
   timestamper:

--- a/resources/docker-compose.yml
+++ b/resources/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '3.8'
 services:
   jenkins:
-    image: opensearchstaging/jenkins:2.387.1-lts-jdk11
+    image: opensearchstaging/jenkins:2.440.2-lts-jdk21
     restart: on-failure
     privileged: true
     tty: true


### PR DESCRIPTION
### Description
Applying necessary changes for Jenkins 2.440.2 upgrade:

- docker-compose.yml: upgrade to `opensearchstaging/jenkins:2.440.2-lts-jdk21`
- baseJenkins.yaml: some plugins relocation due to the requirement in 2.4xx.x
- agent-node-config: `name` tage update for 2.4xx.x

### Issues Resolved
https://github.com/opensearch-project/opensearch-ci/issues/389 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
