### PR TITLE
Change jenkins image to 2.426.3 JDK21

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -28,4 +28,4 @@ jobs:
           platforms: linux/amd64,linux/arm64
           context: "{{defaultContext}}:docker"
           push: true
-          tags: opensearchstaging/jenkins:2.440.2-lts-jdk21,opensearchstaging/jenkins:latest
+          tags: opensearchstaging/jenkins:2.426.3-lts-jdk21,opensearchstaging/jenkins:latest

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM jenkins/jenkins:2.440.2-lts-jdk21
+FROM jenkins/jenkins:2.426.3-lts-jdk21
 LABEL maintainer="OpenSearch"
 ENV JAVA_OPTS -Djenkins.install.runSetupWizard=false
 COPY plugins.txt plugins.txt


### PR DESCRIPTION
### Description
Change Jenkins core image to 2.426.3 JDK21

### Issues Resolved


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
