### PR TITLE
Set durable-task plugin to desired version

### DIFF
--- a/docker/plugins.txt
+++ b/docker/plugins.txt
@@ -1,3 +1,4 @@
+durable-task:547.vd1ea_007d100c
 ace-editor
 adoptopenjdk
 ansicolor


### PR DESCRIPTION
### Description
Set durable-task plugin to 547.vd1ea_007d100c

### Issues Resolved

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
