### PR TITLE
Update deprecated assignments to entries 

### DIFF
--- a/lib/compute/oidc-config.ts
+++ b/lib/compute/oidc-config.ts
@@ -79,14 +79,14 @@ export class OidcConfig {
         roleBased: {
           roles: {
             global: [{
-              assignments: adminUsers,
+              entries: adminUsers.map(user => ({ user })),
               name: 'admin',
               pattern: '.*',
               permissions: OidcConfig.adminRolePermissions
               ,
             },
             {
-              assignments: readOnlyUsers,
+              entries: readOnlyUsers.map(user => ({ user })),
               name: 'read',
               pattern: '.*',
               permissions: OidcConfig.readOnlyRolePermissions,


### PR DESCRIPTION
### Description

- Update deprecated assignments to entries 

- Fix failing role-strategy-plugin

Add syntax changes for jenkins.yaml file from
assignments:
             - admin
to-
entries:
              - user: admin

### Issues Resolved
https://github.com/opensearch-project/opensearch-ci/issues/389

Related documentation
https://issues.jenkins.io/browse/JENKINS-71612

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
