### PR TITLE
Install cronie package on main node

### DIFF
--- a/lib/compute/jenkins-main-node.ts
+++ b/lib/compute/jenkins-main-node.ts
@@ -235,6 +235,7 @@ export class JenkinsMainNode {
     reloadPasswordSecretsArn: string, efsId?: string): InitElement[] {
     return [
       InitPackage.yum('wget'),
+      InitPackage.yum('cronie'),
       InitPackage.yum('openssl'),
       InitPackage.yum('mod_ssl'),
       InitPackage.yum('amazon-efs-utils'),
@@ -243,6 +244,8 @@ export class JenkinsMainNode {
       InitPackage.yum('python3'),
       InitPackage.yum('python3-pip.noarch'),
       InitCommand.shellCommand('pip3 install botocore'),
+      InitCommand.shellCommand('systemctl enable crond.service'),
+      InitCommand.shellCommand('systemctl start crond.service'),
       // eslint-disable-next-line max-len
       InitCommand.shellCommand('sudo wget -nv https://github.com/mikefarah/yq/releases/download/v4.22.1/yq_linux_amd64 -O /usr/bin/yq && sudo chmod +x /usr/bin/yq'),
       // eslint-disable-next-line max-len

--- a/lib/compute/oidc-config.ts
+++ b/lib/compute/oidc-config.ts
@@ -79,14 +79,14 @@ export class OidcConfig {
         roleBased: {
           roles: {
             global: [{
-              entries: adminUsers.map(user => ({ user })),
+              entries: adminUsers.map((user) => ({ user })),
               name: 'admin',
               pattern: '.*',
               permissions: OidcConfig.adminRolePermissions
               ,
             },
             {
-              entries: readOnlyUsers.map(user => ({ user })),
+              entries: readOnlyUsers.map((user) => ({ user })),
               name: 'read',
               pattern: '.*',
               permissions: OidcConfig.readOnlyRolePermissions,

--- a/test/compute/jenkins-main-node.test.ts
+++ b/test/compute/jenkins-main-node.test.ts
@@ -26,8 +26,8 @@ describe('JenkinsMainNode Config Elements', () => {
 
   // THEN
   test('Config elements expected counts', async () => {
-    expect(configElements.filter((e) => e.elementType === 'COMMAND')).toHaveLength(22);
-    expect(configElements.filter((e) => e.elementType === 'PACKAGE')).toHaveLength(9);
+    expect(configElements.filter((e) => e.elementType === 'COMMAND')).toHaveLength(24);
+    expect(configElements.filter((e) => e.elementType === 'PACKAGE')).toHaveLength(10);
     expect(configElements.filter((e) => e.elementType === 'FILE')).toHaveLength(4);
   });
 

--- a/test/data/test_env.yaml
+++ b/test/data/test_env.yaml
@@ -113,6 +113,9 @@ globalCredentialsConfiguration:
   configuration:
     providerFilter: none
     typeFilter: none
+appearance:
+  loginTheme:
+    useDefaultTheme: true
 security:
   apiToken:
     creationOfLegacyTokenEnabled: false
@@ -185,7 +188,7 @@ unclassified:
     apiRateLimitChecker: ThrottleForNormalize
   gitHubPluginConfig:
     hookUrl: http://localhost:8080/github-webhook/
-  gitSCM:
+  scmGit:
     addGitTagAction: false
     allowSecondFetch: false
     createAccountBasedOnEmail: false
@@ -199,14 +202,10 @@ unclassified:
     storage: file
   location:
     adminAddress: address not configured yet <nobody@nowhere>
-  login-theme-plugin:
-    useDefaultTheme: true
   mailer:
     charset: UTF-8
     useSsl: false
     useTls: false
-  pluginImpl:
-    enableCredentialsFromNode: false
   pollSCM:
     pollingThreadCount: 10
   timestamper:


### PR DESCRIPTION
### Description
`cronie` package that provides `crontab` functionality has been deprecated in AL2023 and the work around is to install it manually. Discussion is still on whether to include or not to include in future amis. https://github.com/amazonlinux/amazon-linux-2023/issues/300. 

### Issues Resolved
 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
