### PR TITLE
Add cloudwatch logs for gradle-check job

### DIFF
--- a/lib/compute/jenkins-main-node.ts
+++ b/lib/compute/jenkins-main-node.ts
@@ -393,6 +393,12 @@ export class JenkinsMainNode {
                   auto_removal: true,
                   log_stream_name: 'workflow-logs',
                 },
+                {
+                  file_path: '/var/lib/jenkins/jobs/gradle-check/builds/*/log',
+                  log_group_name: 'JenkinsMainNode/gradle-check.log',
+                  auto_removal: true,
+                  log_stream_name: 'gradle-check.log/{date}',
+                },
               ],
             },
           },


### PR DESCRIPTION
### Description
Add cloudwatch logs for gradle-check job. 
In the future similar configuration can be added if we want to onboard other job logs as well. 

### Issues Resolved
_List any issues this PR will resolve, e.g. Closes [...]._ 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
