### PR TITLE
Ensure packer to provision EC2 instance with imdsv2 enabled

### DIFF
--- a/packer/jenkins-agent-al2-arm64.json
+++ b/packer/jenkins-agent-al2-arm64.json
@@ -36,6 +36,11 @@
         "most_recent":true
       },
       "associate_public_ip_address":false,
+      "metadata_options": {
+        "http_endpoint": "enabled",
+        "http_tokens": "required",
+        "http_put_response_hop_limit": 1
+      },
       "ssh_username":  "ec2-user",
       "ssh_timeout": "3h",
       "tags": {

--- a/packer/jenkins-agent-al2-x64.json
+++ b/packer/jenkins-agent-al2-x64.json
@@ -36,6 +36,11 @@
         "most_recent":true
       },
       "associate_public_ip_address":false,
+      "metadata_options": {
+        "http_endpoint": "enabled",
+        "http_tokens": "required",
+        "http_put_response_hop_limit": 1
+      },
       "ssh_username":  "ec2-user",
       "ssh_timeout": "3h",
       "tags": {

--- a/packer/jenkins-agent-al2023-arm64.json
+++ b/packer/jenkins-agent-al2023-arm64.json
@@ -36,6 +36,11 @@
         "most_recent":true
       },
       "associate_public_ip_address":false,
+      "metadata_options": {
+        "http_endpoint": "enabled",
+        "http_tokens": "required",
+        "http_put_response_hop_limit": 1
+      },
       "ssh_username":  "ec2-user",
       "ssh_timeout": "3h",
       "tags": {

--- a/packer/jenkins-agent-al2023-x64.json
+++ b/packer/jenkins-agent-al2023-x64.json
@@ -36,6 +36,11 @@
         "most_recent":true
       },
       "associate_public_ip_address":false,
+      "metadata_options": {
+        "http_endpoint": "enabled",
+        "http_tokens": "required",
+        "http_put_response_hop_limit": 1
+      },
       "ssh_username":  "ec2-user",
       "ssh_timeout": "3h",
       "tags": {

--- a/packer/jenkins-agent-macos12-x64.json
+++ b/packer/jenkins-agent-macos12-x64.json
@@ -42,6 +42,11 @@
         "most_recent":true
       },
       "associate_public_ip_address":false,
+      "metadata_options": {
+        "http_endpoint": "enabled",
+        "http_tokens": "required",
+        "http_put_response_hop_limit": 1
+      },
       "ssh_username":  "ec2-user", 
       "ssh_timeout": "3h",
       "tenancy": "host",

--- a/packer/jenkins-agent-ubuntu2004-x64.json
+++ b/packer/jenkins-agent-ubuntu2004-x64.json
@@ -36,6 +36,11 @@
         "most_recent":true
       },
       "associate_public_ip_address":false,
+      "metadata_options": {
+        "http_endpoint": "enabled",
+        "http_tokens": "required",
+        "http_put_response_hop_limit": 1
+      },
       "ssh_username":  "ubuntu",
       "ssh_timeout": "3h",
       "tags": {

--- a/packer/jenkins-agent-win2019-x64-gradle-check.json
+++ b/packer/jenkins-agent-win2019-x64-gradle-check.json
@@ -37,6 +37,11 @@
       },
       "user_data_file":"scripts/windows/userdata.ps1",
       "associate_public_ip_address":false,
+      "metadata_options": {
+        "http_endpoint": "enabled",
+        "http_tokens": "required",
+        "http_put_response_hop_limit": 1
+      },
       "communicator":"winrm",
       "winrm_username":"Administrator",
       "winrm_timeout":"40m",

--- a/packer/jenkins-agent-win2019-x64.json
+++ b/packer/jenkins-agent-win2019-x64.json
@@ -36,6 +36,11 @@
         "most_recent":true
       },
       "user_data_file":"scripts/windows/userdata.ps1",
+      "metadata_options": {
+        "http_endpoint": "enabled",
+        "http_tokens": "required",
+        "http_put_response_hop_limit": 1
+      },
       "associate_public_ip_address":false,
       "communicator":"winrm",
       "winrm_username":"Administrator",


### PR DESCRIPTION
### Description
Ensure packer to provision EC2 instance with imdsv2 enabled
Note that this will not make the AMI itself to be imdsv2 only
We currently still maintain the ability for AMI to be both imdsv1 and imdsv2, and use Jenkins EC2 plugin to enforce the imdsv2 during provision of agents.

Thanks.

### Issues Resolved
https://github.com/opensearch-project/opensearch-ci/issues/435

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
