### PR TITLE
Install pigz and unpigz to speed up docker image extraction

### DIFF
--- a/packer/scripts/al2/al2-agent-setups.sh
+++ b/packer/scripts/al2/al2-agent-setups.sh
@@ -33,7 +33,7 @@ EOF
 # Install Temurin JDK 21
 sudo yum install -y temurin-21-jdk
 
-sudo yum install -y which curl git gnupg2 tar net-tools procps-ng python3 python3-devel python3-pip zip unzip jq
+sudo yum install -y which curl git gnupg2 tar net-tools procps-ng python3 python3-devel python3-pip zip unzip jq pigz
 sudo yum install -y docker ntp
 sudo yum groupinstall -y "Development Tools"
 

--- a/packer/scripts/al2023/al2023-agent-setups.sh
+++ b/packer/scripts/al2023/al2023-agent-setups.sh
@@ -17,10 +17,10 @@ fi
 sudo dnf clean all
 sudo rm -rf /var/cache/dnf
 sudo dnf repolist
-sudo dnf update --skip-broken --exclude=openssh* --exclude=docker* -y
+sudo dnf update --skip-broken --exclude=openssh* --exclude=docker* --releasever=latest -y
 
 sudo dnf install -y java-21-amazon-corretto java-21-amazon-corretto-devel
-sudo dnf install -y which git tar net-tools procps-ng python3 python3-devel python3-pip zip unzip jq
+sudo dnf install -y which git tar net-tools procps-ng python3 python3-devel python3-pip zip unzip jq pigz
 sudo dnf install -y docker
 sudo dnf groupinstall -y "Development Tools"
 

--- a/packer/scripts/ubuntu2004/ubuntu2004-agent-setups.sh
+++ b/packer/scripts/ubuntu2004/ubuntu2004-agent-setups.sh
@@ -13,7 +13,7 @@ whoami
 sudo apt-get update -y && (sudo killall -9 apt-get apt 2>&1 || echo)
 sudo apt-get upgrade -y && sudo apt-get install -y software-properties-common && sudo add-apt-repository ppa:jacob/virtualisation -y
 sudo apt-get update -y && sudo apt-get install -y binfmt-support qemu qemu-user qemu-user-static docker.io curl python3-pip && sudo pip3 install awscli
-sudo apt-get install -y docker docker.io docker-compose ntp curl git gnupg2 tar zip unzip jq
+sudo apt-get install -y docker docker.io docker-compose ntp curl git gnupg2 tar zip unzip jq pigz
 sudo apt-get install -y build-essential
 
 # Replace default curl 7.68 on Ubuntu 20.04 with 7.75+ version to support aws-sigv4


### PR DESCRIPTION
### Description
Install pigz and unpigz to speed up docker image extraction

### Issues Resolved
Closes https://github.com/opensearch-project/opensearch-ci/issues/374

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
