### PR TITLE
Make sure Ubuntu is using JDK21 when connecting to Main node

### DIFF
--- a/lib/compute/agent-nodes.ts
+++ b/lib/compute/agent-nodes.ts
@@ -186,7 +186,8 @@ export class AgentNodes {
       numExecutors: 1,
       amiId: 'ami-0182cef5fe6837adb',
       initScript: 'sudo apt-mark hold docker docker.io openssh-server gh grub-efi* shim-signed && docker ps &&'
-      + ' sudo apt-get update -y && (sudo killall -9 apt-get apt 2>&1 || echo) && sudo env "DEBIAN_FRONTEND=noninteractive" apt-get upgrade -y',
+      + ' sudo apt-get update -y && (sudo killall -9 apt-get apt 2>&1 || echo) && sudo env "DEBIAN_FRONTEND=noninteractive" apt-get upgrade -y &&'
+      + ' sudo update-alternatives --set "java" "/usr/lib/jvm/temurin-21-jdk-amd64/bin/java" && java -version',
       remoteFs: '/var/jenkins',
     };
     this.UBUNTU2004_X64_DOCKER_BUILDER = {
@@ -200,7 +201,8 @@ export class AgentNodes {
       numExecutors: 1,
       amiId: 'ami-0182cef5fe6837adb',
       initScript: 'sudo apt-mark hold docker docker.io openssh-server gh grub-efi* shim-signed && docker ps &&'
-      + ' sudo apt-get update -y && (sudo killall -9 apt-get apt 2>&1 || echo) && sudo env "DEBIAN_FRONTEND=noninteractive" apt-get upgrade -y',
+      + ' sudo apt-get update -y && (sudo killall -9 apt-get apt 2>&1 || echo) && sudo env "DEBIAN_FRONTEND=noninteractive" apt-get upgrade -y &&'
+      + ' sudo update-alternatives --set "java" "/usr/lib/jvm/temurin-21-jdk-amd64/bin/java" && java -version',
       remoteFs: '/var/jenkins',
     };
     this.MACOS13_X64_MULTI_HOST = {


### PR DESCRIPTION
### Description
Make sure Ubuntu is using JDK21 when connecting to Main node

### Issues Resolved

```

Jul 23, 2024 12:04:05 AM hudson.plugins.ec2.EC2Cloud
INFO: Creating ~/.hudson-run-init
Jul 23, 2024 12:04:05 AM hudson.plugins.ec2.EC2Cloud
INFO: Verifying: java -fullversion
openjdk full version "11.0.22+7"
Jul 23, 2024 12:04:08 AM hudson.plugins.ec2.EC2Cloud
INFO: Verifying: which scp
/usr/bin/scp
Jul 23, 2024 12:04:08 AM hudson.plugins.ec2.EC2Cloud
INFO: Copying remoting.jar to: /tmp
Jul 23, 2024 12:04:08 AM hudson.plugins.ec2.EC2Cloud
INFO: Launching remoting agent (via Trilead SSH2 Connection):  java  -jar /tmp/remoting.jar -workDir /var/jenkins
<===[JENKINS REMOTING CAPACITY]===>Remoting version: 3160.vd76b_9ddd10cc
Launcher: EC2UnixLauncher
Communication Protocol: Standard in/out
This is a Unix agent
Evacuated stdout
Agent successfully connected and online
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
