### PR TITLE
Disable auto log file removal for Jenkins gradle check logs

### DIFF
--- a/lib/compute/jenkins-main-node.ts
+++ b/lib/compute/jenkins-main-node.ts
@@ -396,7 +396,7 @@ export class JenkinsMainNode {
                 {
                   file_path: '/var/lib/jenkins/jobs/gradle-check/builds/*/log',
                   log_group_name: 'JenkinsMainNode/gradle-check.log',
-                  auto_removal: true,
+                  auto_removal: false,
                   log_stream_name: 'gradle-check.log/{date}',
                 },
               ],


### PR DESCRIPTION
### Description
Disable auto log file removal for Jenkins gradle check logs

### Issues Resolved
https://github.com/opensearch-project/opensearch-ci/issues/484

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
