### PR TITLE
Update spare instance number on al2023 docker host

### DIFF
--- a/lib/compute/agent-nodes.ts
+++ b/lib/compute/agent-nodes.ts
@@ -80,7 +80,7 @@ export class AgentNodes {
       instanceType: 'M54xlarge',
       remoteUser: 'ec2-user',
       maxTotalUses: -1,
-      minimumNumberOfSpareInstances: 1,
+      minimumNumberOfSpareInstances: 4,
       numExecutors: 3,
       amiId: 'ami-0e8c1c93cdfb4ce70',
       initScript: 'sudo dnf clean all && sudo rm -rf /var/cache/dnf && sudo dnf repolist &&'
@@ -122,7 +122,7 @@ export class AgentNodes {
       instanceType: 'M6g4xlarge',
       remoteUser: 'ec2-user',
       maxTotalUses: -1,
-      minimumNumberOfSpareInstances: 1,
+      minimumNumberOfSpareInstances: 4,
       numExecutors: 3,
       amiId: 'ami-07171e0264441db0a',
       initScript: 'sudo dnf clean all && sudo rm -rf /var/cache/dnf && sudo dnf repolist &&'


### PR DESCRIPTION
### Description
Update spare instance number on al2023 docker host

old: 3 spare * 4 executors = 12 waiting
new: 4 spare * 3 executors = 12 waiting.

That is because the old name for M5 M6g is DOCKER_HOST_EXTRA which is only used for integ.
There used to be DOCKER_HOST with 3 spare, and DOCKER_HOST_EXTRA with 1 spare.
Now I remove old DOCKER_HOST and rename EXTRA to the same name.

Therefore the new DOCKER_HOST needs to have 4 spare instances.

Thanks.

### Issues Resolved
https://github.com/opensearch-project/opensearch-build/issues/5082

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
