### PR TITLE
Update windows boot delay from 7.5 seconds to 180 seconds

### DIFF
--- a/lib/compute/agent-node-config.ts
+++ b/lib/compute/agent-node-config.ts
@@ -327,7 +327,7 @@ export class AgentNodeConfig {
       amiType:
          {
            windowsData: {
-             allowSelfSignedCertificate: false, bootDelay: '7.5', specifyPassword: false, useHTTPS: false,
+             allowSelfSignedCertificate: false, bootDelay: '180', specifyPassword: false, useHTTPS: false,
            },
          },
       associatePublicIp: false,


### PR DESCRIPTION
### Description
Update windows boot delay from 7.5 seconds to 180 seconds

```
Indicate here the time in seconds to wait for the machine to be ready once the plugin detects WinRM is available.
...
 A safe value has been found to be 3 minutes. 
```

```
WinRM service responded. Waiting 180000ms for WinRM service to stabilize on EC2 (Amazon_ec2_cloud) - jenkinsAgentNode-Jenkins-Agent-Windows2019-X64-M54xlarge-Docker-Builder (<>)
```

### Issues Resolved
opensearch-project/opensearch-build#5004

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
