### PR TITLE
Replace py39-python-installer with python39 due to port removal

### DIFF
--- a/packer/scripts/macos/macos-agentsetup.sh
+++ b/packer/scripts/macos/macos-agentsetup.sh
@@ -76,7 +76,7 @@ cd MacPorts-2.9.3
 cd .. && rm -rf MacPorts-2.9.3.tar.gz
 export PATH=/opt/local/bin:$PATH
 sudo port -v selfupdate
-yes | sudo port install py39-python-install
+yes | sudo port install python39
 sudo port select --set python python39
 sudo port select --set python3 python39
 


### PR DESCRIPTION
### Description
Replace py39-python-installer with python39 due to port removal

### Issues Resolved
https://github.com/opensearch-project/opensearch-build/issues/5096#issuecomment-2465866042

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
