### PR TITLE
Install github-oauth plugin

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -7,6 +7,7 @@ on:
 
 jobs:
   docker:
+    if: github.repository == 'opensearch-project/opensearch-ci'
     runs-on: ubuntu-latest
     steps:
       -

--- a/docker/plugins.txt
+++ b/docker/plugins.txt
@@ -73,3 +73,4 @@ job-import-plugin
 workflow-multibranch
 pipeline-utility-steps
 blueocean
+github-oauth


### PR DESCRIPTION
### Description
This change installs github-oauth plugin version: `597.ve0c3480fcb_d0 `
This change **DOES NOT** enable GitHub Auth yet.
Also adds conditional check to the docker workflow to only execute for this repo.

### Issues Resolved
related https://github.com/opensearch-project/opensearch-ci/issues/506

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
