### PR TITLE
Restore previous secrets and update cfn parameter

### DIFF
--- a/lib/ci-config-stack.ts
+++ b/lib/ci-config-stack.ts
@@ -21,6 +21,8 @@ export class CIConfigStack extends Stack {
 
   static readonly REDIRECT_URL_SECRET_EXPORT_VALUE: string = 'redirectUrlSecret';
 
+  static readonly OIDC_CONFIGURATION_VALUE_SECRET_EXPORT_VALUE: string = 'OIDCConfigValueSecret';
+
   static readonly AUTH_CONFIGURATION_VALUE_SECRET_EXPORT_VALUE: string = 'authConfigValueSecret';
 
   static readonly CASC_RELOAD_TOKEN_SECRET_EXPORT_VALUE: string = 'casc';
@@ -43,10 +45,12 @@ export class CIConfigStack extends Stack {
     const redirectUrlSecret = new Secret(this, 'redirectUrl', {
       description: 'Redirect url for Jenkins',
     });
+    const OIDCConfigValuesSecret = new Secret(this, 'OIDCConfigValues', {
+      description: 'OIDC params in JSON format',
+    });
     const authConfigValuesSecret = new Secret(this, 'authConfigValues', {
       description: 'Auth credentials in JSON format',
     });
-
     const CascReloadTokenValuesSecret = new Secret(this, 'CascReloadTokenValue', {
       description: 'Reload token (password) required for configuration as code plugin',
     });
@@ -74,6 +78,11 @@ export class CIConfigStack extends Stack {
     new CfnOutput(this, 'redirectUrlSecret', {
       value: redirectUrlSecret.secretArn,
       exportName: CIConfigStack.REDIRECT_URL_SECRET_EXPORT_VALUE,
+    });
+
+    new CfnOutput(this, 'OIDCConfigValuesSecret', {
+      value: OIDCConfigValuesSecret.secretArn,
+      exportName: CIConfigStack.OIDC_CONFIGURATION_VALUE_SECRET_EXPORT_VALUE,
     });
 
     new CfnOutput(this, 'authConfigValuesSecret', {

--- a/lib/ci-stack.ts
+++ b/lib/ci-stack.ts
@@ -31,7 +31,7 @@ export interface CIStackProps extends StackProps {
   /** Should the Jenkins use https  */
   readonly useSsl?: boolean;
   /** Type of login mechanism to adopt */
-  readonly authType?:string;
+  readonly authType?: string;
   /** Restrict jenkins access to */
   readonly restrictServerAccessTo?: IPeer;
   /** Additional verification during deployment and resource startup. */
@@ -123,8 +123,8 @@ export class CIStack extends Stack {
     const additionalCommandsContext = `${props?.additionalCommands ?? this.node.tryGetContext('additionalCommands')}`;
 
     // Setting CfnParameters to record the value in cloudFormation
-    new CfnParameter(this, 'runWithOidc', {
-      description: 'If the jenkins instance should use OIDC + federate',
+    new CfnParameter(this, 'authType', {
+      description: 'Auth type for jenkins login',
       default: authType,
     });
 


### PR DESCRIPTION
### Description
While updating the currently deployed stack, removing the old value is causing issues as ci-stack is dependent on it. Hence, the current stack won't delete the oidc secret. This change keeps the value as is along with new auth values

### Issues Resolved
_List any issues this PR will resolve, e.g. Closes [...]._ 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
