### PR TITLE
Add config helper utility to improve modifying Jenkins CASC yaml

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,7 +6,7 @@ node_modules
 .DS_Store
 # We do not want to track this file as it is generated only if user provides certain params.
 resources/jenkins.yaml
-
+.coverage
 
 # CDK asset staging directory
 .cdk.staging

--- a/README.md
+++ b/README.md
@@ -127,7 +127,7 @@ Steps:
         "clientSecret": "example_password",
         "serverConfiguration": {
             "wellKnown": {
-                "wellKnownOpenIDConfigurationUrl": "https://my.openid-config.com"
+                "wellKnownOpenIDConfigurationUrl": "https://example.openid.com/.well-known/openid-configuration"
             }
         }
     }

--- a/README.md
+++ b/README.md
@@ -125,10 +125,11 @@ Steps:
     {
         "clientId": "example_id",
         "clientSecret": "example_password",
-        "wellKnownOpenIDConfigurationUrl": "https://www.example.com",
-        "tokenServerUrl": "https://example.com/token",
-        "authorizationServerUrl": "https://example.com/authorize",
-        "userInfoServerUrl": "https://example.com/userinfo"
+        "serverConfiguration": {
+            "wellKnown": {
+                "wellKnownOpenIDConfigurationUrl": "https://my.openid-config.com"
+            }
+        }
     }
     ```
 1. **GitHub Authentication**: Use GitHub as Authentication mechanism for jenkins. This set up uses [github-oauth](https://plugins.jenkins.io/github-oauth/) plugin.

--- a/README.md
+++ b/README.md
@@ -289,7 +289,7 @@ Useful links
 
 ![Plantuml diagram, see ./diagrams/opensearch-ci-overview.puml for source](./diagrams/opensearch-ci-overview.svg)
 
-Built using [AWS Cloud Development Kit](https://aws.amazon.com/cdk/) the configuration of the CI systems will be available for replication in your own accounts.  The Jenkins instance will be hardened and publically visible, connected to GitHub to make build notifications easy for everyone to see.
+Built using [AWS Cloud Development Kit](https://aws.amazon.com/cdk/) the configuration of the CI systems will be available for replication in your own accounts.  The Jenkins instance will be hardened and publicly visible, connected to GitHub to make build notifications easy for everyone to see.
 
 ## Contributing
 

--- a/configHelper/.coveragerc
+++ b/configHelper/.coveragerc
@@ -1,0 +1,6 @@
+[run]
+source = configHelper
+
+[report]
+omit =
+   */tests/*

--- a/configHelper/Pipfile
+++ b/configHelper/Pipfile
@@ -13,8 +13,5 @@ pytest = "*"
 pytest-mock = "*"
 coverage = "*"
 
-[requires]
-python_version = "3"
-
 [scripts]
 test = "coverage run -m pytest"

--- a/configHelper/Pipfile
+++ b/configHelper/Pipfile
@@ -1,0 +1,20 @@
+[[source]]
+url = "https://pypi.org/simple"
+verify_ssl = true
+name = "pypi"
+
+[packages]
+boto3 = "*"
+argparse = "*"
+pyyaml = "*"
+
+[dev-packages]
+pytest = "*"
+pytest-mock = "*"
+coverage = "*"
+
+[requires]
+python_version = "3"
+
+[scripts]
+test = "coverage run -m pytest"

--- a/configHelper/Pipfile
+++ b/configHelper/Pipfile
@@ -14,4 +14,4 @@ pytest-mock = "*"
 coverage = "*"
 
 [scripts]
-test = "coverage run -m pytest"
+test = "coverage run -m pytest --log-cli-level=INFO"

--- a/configHelper/Pipfile.lock
+++ b/configHelper/Pipfile.lock
@@ -1,0 +1,302 @@
+{
+    "_meta": {
+        "hash": {
+            "sha256": "8cbc849aee3948983df19d6a58f19845fa35a9802143beb54b7ae3d8027817f9"
+        },
+        "pipfile-spec": 6,
+        "requires": {},
+        "sources": [
+            {
+                "name": "pypi",
+                "url": "https://pypi.org/simple",
+                "verify_ssl": true
+            }
+        ]
+    },
+    "default": {
+        "argparse": {
+            "hashes": [
+                "sha256:62b089a55be1d8949cd2bc7e0df0bddb9e028faefc8c32038cc84862aefdd6e4",
+                "sha256:c31647edb69fd3d465a847ea3157d37bed1f95f19760b11a47aa91c04b666314"
+            ],
+            "index": "pypi",
+            "version": "==1.4.0"
+        },
+        "boto3": {
+            "hashes": [
+                "sha256:c81223488607457dacb7829ee0c99803c664593b34a2b0f86c71d421e7c3469a",
+                "sha256:d5671226819f6a78e31b1f37bd60f194afb8203254a543d06bdfb76de7d79236"
+            ],
+            "index": "pypi",
+            "markers": "python_version >= '3.8'",
+            "version": "==1.35.95"
+        },
+        "botocore": {
+            "hashes": [
+                "sha256:a672406f748ad6a5b2fb7ea0d8394539eb4fda5332fc5373467d232c4bb27b12",
+                "sha256:b03d2d7cc58a16aa96a7e8f21941b766e98abc6ea74f61a63de7dc26c03641d3"
+            ],
+            "markers": "python_version >= '3.8'",
+            "version": "==1.35.95"
+        },
+        "jmespath": {
+            "hashes": [
+                "sha256:02e2e4cc71b5bcab88332eebf907519190dd9e6e82107fa7f83b1003a6252980",
+                "sha256:90261b206d6defd58fdd5e85f478bf633a2901798906be2ad389150c5c60edbe"
+            ],
+            "markers": "python_version >= '3.7'",
+            "version": "==1.0.1"
+        },
+        "python-dateutil": {
+            "hashes": [
+                "sha256:37dd54208da7e1cd875388217d5e00ebd4179249f90fb72437e91a35459a0ad3",
+                "sha256:a8b2bc7bffae282281c8140a97d3aa9c14da0b136dfe83f850eea9a5f7470427"
+            ],
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2'",
+            "version": "==2.9.0.post0"
+        },
+        "pyyaml": {
+            "hashes": [
+                "sha256:01179a4a8559ab5de078078f37e5c1a30d76bb88519906844fd7bdea1b7729ff",
+                "sha256:0833f8694549e586547b576dcfaba4a6b55b9e96098b36cdc7ebefe667dfed48",
+                "sha256:0a9a2848a5b7feac301353437eb7d5957887edbf81d56e903999a75a3d743086",
+                "sha256:0b69e4ce7a131fe56b7e4d770c67429700908fc0752af059838b1cfb41960e4e",
+                "sha256:0ffe8360bab4910ef1b9e87fb812d8bc0a308b0d0eef8c8f44e0254ab3b07133",
+                "sha256:11d8f3dd2b9c1207dcaf2ee0bbbfd5991f571186ec9cc78427ba5bd32afae4b5",
+                "sha256:17e311b6c678207928d649faa7cb0d7b4c26a0ba73d41e99c4fff6b6c3276484",
+                "sha256:1e2120ef853f59c7419231f3bf4e7021f1b936f6ebd222406c3b60212205d2ee",
+                "sha256:1f71ea527786de97d1a0cc0eacd1defc0985dcf6b3f17bb77dcfc8c34bec4dc5",
+                "sha256:23502f431948090f597378482b4812b0caae32c22213aecf3b55325e049a6c68",
+                "sha256:24471b829b3bf607e04e88d79542a9d48bb037c2267d7927a874e6c205ca7e9a",
+                "sha256:29717114e51c84ddfba879543fb232a6ed60086602313ca38cce623c1d62cfbf",
+                "sha256:2e99c6826ffa974fe6e27cdb5ed0021786b03fc98e5ee3c5bfe1fd5015f42b99",
+                "sha256:39693e1f8320ae4f43943590b49779ffb98acb81f788220ea932a6b6c51004d8",
+                "sha256:3ad2a3decf9aaba3d29c8f537ac4b243e36bef957511b4766cb0057d32b0be85",
+                "sha256:3b1fdb9dc17f5a7677423d508ab4f243a726dea51fa5e70992e59a7411c89d19",
+                "sha256:41e4e3953a79407c794916fa277a82531dd93aad34e29c2a514c2c0c5fe971cc",
+                "sha256:43fa96a3ca0d6b1812e01ced1044a003533c47f6ee8aca31724f78e93ccc089a",
+                "sha256:50187695423ffe49e2deacb8cd10510bc361faac997de9efef88badc3bb9e2d1",
+                "sha256:5ac9328ec4831237bec75defaf839f7d4564be1e6b25ac710bd1a96321cc8317",
+                "sha256:5d225db5a45f21e78dd9358e58a98702a0302f2659a3c6cd320564b75b86f47c",
+                "sha256:6395c297d42274772abc367baaa79683958044e5d3835486c16da75d2a694631",
+                "sha256:688ba32a1cffef67fd2e9398a2efebaea461578b0923624778664cc1c914db5d",
+                "sha256:68ccc6023a3400877818152ad9a1033e3db8625d899c72eacb5a668902e4d652",
+                "sha256:70b189594dbe54f75ab3a1acec5f1e3faa7e8cf2f1e08d9b561cb41b845f69d5",
+                "sha256:797b4f722ffa07cc8d62053e4cff1486fa6dc094105d13fea7b1de7d8bf71c9e",
+                "sha256:7c36280e6fb8385e520936c3cb3b8042851904eba0e58d277dca80a5cfed590b",
+                "sha256:7e7401d0de89a9a855c839bc697c079a4af81cf878373abd7dc625847d25cbd8",
+                "sha256:80bab7bfc629882493af4aa31a4cfa43a4c57c83813253626916b8c7ada83476",
+                "sha256:82d09873e40955485746739bcb8b4586983670466c23382c19cffecbf1fd8706",
+                "sha256:8388ee1976c416731879ac16da0aff3f63b286ffdd57cdeb95f3f2e085687563",
+                "sha256:8824b5a04a04a047e72eea5cec3bc266db09e35de6bdfe34c9436ac5ee27d237",
+                "sha256:8b9c7197f7cb2738065c481a0461e50ad02f18c78cd75775628afb4d7137fb3b",
+                "sha256:9056c1ecd25795207ad294bcf39f2db3d845767be0ea6e6a34d856f006006083",
+                "sha256:936d68689298c36b53b29f23c6dbb74de12b4ac12ca6cfe0e047bedceea56180",
+                "sha256:9b22676e8097e9e22e36d6b7bda33190d0d400f345f23d4065d48f4ca7ae0425",
+                "sha256:a4d3091415f010369ae4ed1fc6b79def9416358877534caf6a0fdd2146c87a3e",
+                "sha256:a8786accb172bd8afb8be14490a16625cbc387036876ab6ba70912730faf8e1f",
+                "sha256:a9f8c2e67970f13b16084e04f134610fd1d374bf477b17ec1599185cf611d725",
+                "sha256:bc2fa7c6b47d6bc618dd7fb02ef6fdedb1090ec036abab80d4681424b84c1183",
+                "sha256:c70c95198c015b85feafc136515252a261a84561b7b1d51e3384e0655ddf25ab",
+                "sha256:cc1c1159b3d456576af7a3e4d1ba7e6924cb39de8f67111c735f6fc832082774",
+                "sha256:ce826d6ef20b1bc864f0a68340c8b3287705cae2f8b4b1d932177dcc76721725",
+                "sha256:d584d9ec91ad65861cc08d42e834324ef890a082e591037abe114850ff7bbc3e",
+                "sha256:d7fded462629cfa4b685c5416b949ebad6cec74af5e2d42905d41e257e0869f5",
+                "sha256:d84a1718ee396f54f3a086ea0a66d8e552b2ab2017ef8b420e92edbc841c352d",
+                "sha256:d8e03406cac8513435335dbab54c0d385e4a49e4945d2909a581c83647ca0290",
+                "sha256:e10ce637b18caea04431ce14fabcf5c64a1c61ec9c56b071a4b7ca131ca52d44",
+                "sha256:ec031d5d2feb36d1d1a24380e4db6d43695f3748343d99434e6f5f9156aaa2ed",
+                "sha256:ef6107725bd54b262d6dedcc2af448a266975032bc85ef0172c5f059da6325b4",
+                "sha256:efdca5630322a10774e8e98e1af481aad470dd62c3170801852d752aa7a783ba",
+                "sha256:f753120cb8181e736c57ef7636e83f31b9c0d1722c516f7e86cf15b7aa57ff12",
+                "sha256:ff3824dc5261f50c9b0dfb3be22b4567a6f938ccce4587b38952d85fd9e9afe4"
+            ],
+            "index": "pypi",
+            "markers": "python_version >= '3.8'",
+            "version": "==6.0.2"
+        },
+        "s3transfer": {
+            "hashes": [
+                "sha256:244a76a24355363a68164241438de1b72f8781664920260c48465896b712a41e",
+                "sha256:29edc09801743c21eb5ecbc617a152df41d3c287f67b615f73e5f750583666a7"
+            ],
+            "markers": "python_version >= '3.8'",
+            "version": "==0.10.4"
+        },
+        "six": {
+            "hashes": [
+                "sha256:4721f391ed90541fddacab5acf947aa0d3dc7d27b2e1e8eda2be8970586c3274",
+                "sha256:ff70335d468e7eb6ec65b95b99d3a2836546063f63acc5171de367e834932a81"
+            ],
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2'",
+            "version": "==1.17.0"
+        },
+        "urllib3": {
+            "hashes": [
+                "sha256:1cee9ad369867bfdbbb48b7dd50374c0967a0bb7710050facf0dd6911440e3df",
+                "sha256:f8c5449b3cf0861679ce7e0503c7b44b5ec981bec0d1d3795a07f1ba96f0204d"
+            ],
+            "markers": "python_version >= '3.9'",
+            "version": "==2.3.0"
+        }
+    },
+    "develop": {
+        "coverage": {
+            "hashes": [
+                "sha256:05fca8ba6a87aabdd2d30d0b6c838b50510b56cdcfc604d40760dae7153b73d9",
+                "sha256:0aa9692b4fdd83a4647eeb7db46410ea1322b5ed94cd1715ef09d1d5922ba87f",
+                "sha256:0c807ca74d5a5e64427c8805de15b9ca140bba13572d6d74e262f46f50b13273",
+                "sha256:0d7a2bf79378d8fb8afaa994f91bfd8215134f8631d27eba3e0e2c13546ce994",
+                "sha256:0f460286cb94036455e703c66988851d970fdfd8acc2a1122ab7f4f904e4029e",
+                "sha256:204a8238afe787323a8b47d8be4df89772d5c1e4651b9ffa808552bdf20e1d50",
+                "sha256:2396e8116db77789f819d2bc8a7e200232b7a282c66e0ae2d2cd84581a89757e",
+                "sha256:254f1a3b1eef5f7ed23ef265eaa89c65c8c5b6b257327c149db1ca9d4a35f25e",
+                "sha256:26bcf5c4df41cad1b19c84af71c22cbc9ea9a547fc973f1f2cc9a290002c8b3c",
+                "sha256:27c6e64726b307782fa5cbe531e7647aee385a29b2107cd87ba7c0105a5d3853",
+                "sha256:299e91b274c5c9cdb64cbdf1b3e4a8fe538a7a86acdd08fae52301b28ba297f8",
+                "sha256:2bcfa46d7709b5a7ffe089075799b902020b62e7ee56ebaed2f4bdac04c508d8",
+                "sha256:2ccf240eb719789cedbb9fd1338055de2761088202a9a0b73032857e53f612fe",
+                "sha256:32ee6d8491fcfc82652a37109f69dee9a830e9379166cb73c16d8dc5c2915165",
+                "sha256:3f7b444c42bbc533aaae6b5a2166fd1a797cdb5eb58ee51a92bee1eb94a1e1cb",
+                "sha256:457574f4599d2b00f7f637a0700a6422243b3565509457b2dbd3f50703e11f59",
+                "sha256:489a01f94aa581dbd961f306e37d75d4ba16104bbfa2b0edb21d29b73be83609",
+                "sha256:4bcc276261505d82f0ad426870c3b12cb177752834a633e737ec5ee79bbdff18",
+                "sha256:4e0de1e902669dccbf80b0415fb6b43d27edca2fbd48c74da378923b05316098",
+                "sha256:4e4630c26b6084c9b3cb53b15bd488f30ceb50b73c35c5ad7871b869cb7365fd",
+                "sha256:4eea95ef275de7abaef630c9b2c002ffbc01918b726a39f5a4353916ec72d2f3",
+                "sha256:507a20fc863cae1d5720797761b42d2d87a04b3e5aeb682ef3b7332e90598f43",
+                "sha256:54a5f0f43950a36312155dae55c505a76cd7f2b12d26abeebbe7a0b36dbc868d",
+                "sha256:55b201b97286cf61f5e76063f9e2a1d8d2972fc2fcfd2c1272530172fd28c359",
+                "sha256:59af35558ba08b758aec4d56182b222976330ef8d2feacbb93964f576a7e7a90",
+                "sha256:5c912978f7fbf47ef99cec50c4401340436d200d41d714c7a4766f377c5b7b78",
+                "sha256:656c82b8a0ead8bba147de9a89bda95064874c91a3ed43a00e687f23cc19d53a",
+                "sha256:6713ba4b4ebc330f3def51df1d5d38fad60b66720948112f114968feb52d3f99",
+                "sha256:675cefc4c06e3b4c876b85bfb7c59c5e2218167bbd4da5075cbe3b5790a28988",
+                "sha256:6f93531882a5f68c28090f901b1d135de61b56331bba82028489bc51bdd818d2",
+                "sha256:714f942b9c15c3a7a5fe6876ce30af831c2ad4ce902410b7466b662358c852c0",
+                "sha256:79109c70cc0882e4d2d002fe69a24aa504dec0cc17169b3c7f41a1d341a73694",
+                "sha256:7bbd8c8f1b115b892e34ba66a097b915d3871db7ce0e6b9901f462ff3a975377",
+                "sha256:7ed2f37cfce1ce101e6dffdfd1c99e729dd2ffc291d02d3e2d0af8b53d13840d",
+                "sha256:7fb105327c8f8f0682e29843e2ff96af9dcbe5bab8eeb4b398c6a33a16d80a23",
+                "sha256:89d76815a26197c858f53c7f6a656686ec392b25991f9e409bcef020cd532312",
+                "sha256:9a7cfb50515f87f7ed30bc882f68812fd98bc2852957df69f3003d22a2aa0abf",
+                "sha256:9e1747bab246d6ff2c4f28b4d186b205adced9f7bd9dc362051cc37c4a0c7bd6",
+                "sha256:9e80eba8801c386f72e0712a0453431259c45c3249f0009aff537a517b52942b",
+                "sha256:a01ec4af7dfeb96ff0078ad9a48810bb0cc8abcb0115180c6013a6b26237626c",
+                "sha256:a372c89c939d57abe09e08c0578c1d212e7a678135d53aa16eec4430adc5e690",
+                "sha256:a3b204c11e2b2d883946fe1d97f89403aa1811df28ce0447439178cc7463448a",
+                "sha256:a534738b47b0de1995f85f582d983d94031dffb48ab86c95bdf88dc62212142f",
+                "sha256:a5e37dc41d57ceba70956fa2fc5b63c26dba863c946ace9705f8eca99daecdc4",
+                "sha256:aa744da1820678b475e4ba3dfd994c321c5b13381d1041fe9c608620e6676e25",
+                "sha256:ab32947f481f7e8c763fa2c92fd9f44eeb143e7610c4ca9ecd6a36adab4081bd",
+                "sha256:abb02e2f5a3187b2ac4cd46b8ced85a0858230b577ccb2c62c81482ca7d18852",
+                "sha256:b330368cb99ef72fcd2dc3ed260adf67b31499584dc8a20225e85bfe6f6cfed0",
+                "sha256:bc67deb76bc3717f22e765ab3e07ee9c7a5e26b9019ca19a3b063d9f4b874244",
+                "sha256:c0b1818063dc9e9d838c09e3a473c1422f517889436dd980f5d721899e66f315",
+                "sha256:c56e097019e72c373bae32d946ecf9858fda841e48d82df7e81c63ac25554078",
+                "sha256:c7827a5bc7bdb197b9e066cdf650b2887597ad124dd99777332776f7b7c7d0d0",
+                "sha256:ccc2b70a7ed475c68ceb548bf69cec1e27305c1c2606a5eb7c3afff56a1b3b27",
+                "sha256:d37a84878285b903c0fe21ac8794c6dab58150e9359f1aaebbeddd6412d53132",
+                "sha256:e2f0280519e42b0a17550072861e0bc8a80a0870de260f9796157d3fca2733c5",
+                "sha256:e4ae5ac5e0d1e4edfc9b4b57b4cbecd5bc266a6915c500f358817a8496739247",
+                "sha256:e67926f51821b8e9deb6426ff3164870976fe414d033ad90ea75e7ed0c2e5022",
+                "sha256:e78b270eadb5702938c3dbe9367f878249b5ef9a2fcc5360ac7bff694310d17b",
+                "sha256:ea3c8f04b3e4af80e17bab607c386a830ffc2fb88a5484e1df756478cf70d1d3",
+                "sha256:ec22b5e7fe7a0fa8509181c4aac1db48f3dd4d3a566131b313d1efc102892c18",
+                "sha256:f4f620668dbc6f5e909a0946a877310fb3d57aea8198bde792aae369ee1c23b5",
+                "sha256:fd34e7b3405f0cc7ab03d54a334c17a9e802897580d964bd8c2001f4b9fd488f"
+            ],
+            "index": "pypi",
+            "markers": "python_version >= '3.9'",
+            "version": "==7.6.10"
+        },
+        "exceptiongroup": {
+            "hashes": [
+                "sha256:3111b9d131c238bec2f8f516e123e14ba243563fb135d3fe885990585aa7795b",
+                "sha256:47c2edf7c6738fafb49fd34290706d1a1a2f4d1c6df275526b62cbb4aa5393cc"
+            ],
+            "markers": "python_version >= '3.7'",
+            "version": "==1.2.2"
+        },
+        "iniconfig": {
+            "hashes": [
+                "sha256:2d91e135bf72d31a410b17c16da610a82cb55f6b0477d1a902134b24a455b8b3",
+                "sha256:b6a85871a79d2e3b22d2d1b94ac2824226a63c6b741c88f7ae975f18b6778374"
+            ],
+            "markers": "python_version >= '3.7'",
+            "version": "==2.0.0"
+        },
+        "packaging": {
+            "hashes": [
+                "sha256:09abb1bccd265c01f4a3aa3f7a7db064b36514d2cba19a2f694fe6150451a759",
+                "sha256:c228a6dc5e932d346bc5739379109d49e8853dd8223571c7c5b55260edc0b97f"
+            ],
+            "markers": "python_version >= '3.8'",
+            "version": "==24.2"
+        },
+        "pluggy": {
+            "hashes": [
+                "sha256:2cffa88e94fdc978c4c574f15f9e59b7f4201d439195c3715ca9e2486f1d0cf1",
+                "sha256:44e1ad92c8ca002de6377e165f3e0f1be63266ab4d554740532335b9d75ea669"
+            ],
+            "markers": "python_version >= '3.8'",
+            "version": "==1.5.0"
+        },
+        "pytest": {
+            "hashes": [
+                "sha256:50e16d954148559c9a74109af1eaf0c945ba2d8f30f0a3d3335edde19788b6f6",
+                "sha256:965370d062bce11e73868e0335abac31b4d3de0e82f4007408d242b4f8610761"
+            ],
+            "index": "pypi",
+            "markers": "python_version >= '3.8'",
+            "version": "==8.3.4"
+        },
+        "pytest-mock": {
+            "hashes": [
+                "sha256:0b72c38033392a5f4621342fe11e9219ac11ec9d375f8e2a0c164539e0d70f6f",
+                "sha256:2719255a1efeceadbc056d6bf3df3d1c5015530fb40cf347c0f9afac88410bd0"
+            ],
+            "index": "pypi",
+            "markers": "python_version >= '3.8'",
+            "version": "==3.14.0"
+        },
+        "tomli": {
+            "hashes": [
+                "sha256:023aa114dd824ade0100497eb2318602af309e5a55595f76b626d6d9f3b7b0a6",
+                "sha256:02abe224de6ae62c19f090f68da4e27b10af2b93213d36cf44e6e1c5abd19fdd",
+                "sha256:286f0ca2ffeeb5b9bd4fcc8d6c330534323ec51b2f52da063b11c502da16f30c",
+                "sha256:2d0f2fdd22b02c6d81637a3c95f8cd77f995846af7414c5c4b8d0545afa1bc4b",
+                "sha256:33580bccab0338d00994d7f16f4c4ec25b776af3ffaac1ed74e0b3fc95e885a8",
+                "sha256:400e720fe168c0f8521520190686ef8ef033fb19fc493da09779e592861b78c6",
+                "sha256:40741994320b232529c802f8bc86da4e1aa9f413db394617b9a256ae0f9a7f77",
+                "sha256:465af0e0875402f1d226519c9904f37254b3045fc5084697cefb9bdde1ff99ff",
+                "sha256:4a8f6e44de52d5e6c657c9fe83b562f5f4256d8ebbfe4ff922c495620a7f6cea",
+                "sha256:4e340144ad7ae1533cb897d406382b4b6fede8890a03738ff1683af800d54192",
+                "sha256:678e4fa69e4575eb77d103de3df8a895e1591b48e740211bd1067378c69e8249",
+                "sha256:6972ca9c9cc9f0acaa56a8ca1ff51e7af152a9f87fb64623e31d5c83700080ee",
+                "sha256:7fc04e92e1d624a4a63c76474610238576942d6b8950a2d7f908a340494e67e4",
+                "sha256:889f80ef92701b9dbb224e49ec87c645ce5df3fa2cc548664eb8a25e03127a98",
+                "sha256:8d57ca8095a641b8237d5b079147646153d22552f1c637fd3ba7f4b0b29167a8",
+                "sha256:8dd28b3e155b80f4d54beb40a441d366adcfe740969820caf156c019fb5c7ec4",
+                "sha256:9316dc65bed1684c9a98ee68759ceaed29d229e985297003e494aa825ebb0281",
+                "sha256:a198f10c4d1b1375d7687bc25294306e551bf1abfa4eace6650070a5c1ae2744",
+                "sha256:a38aa0308e754b0e3c67e344754dff64999ff9b513e691d0e786265c93583c69",
+                "sha256:a92ef1a44547e894e2a17d24e7557a5e85a9e1d0048b0b5e7541f76c5032cb13",
+                "sha256:ac065718db92ca818f8d6141b5f66369833d4a80a9d74435a268c52bdfa73140",
+                "sha256:b82ebccc8c8a36f2094e969560a1b836758481f3dc360ce9a3277c65f374285e",
+                "sha256:c954d2250168d28797dd4e3ac5cf812a406cd5a92674ee4c8f123c889786aa8e",
+                "sha256:cb55c73c5f4408779d0cf3eef9f762b9c9f147a77de7b258bef0a5628adc85cc",
+                "sha256:cd45e1dc79c835ce60f7404ec8119f2eb06d38b1deba146f07ced3bbc44505ff",
+                "sha256:d3f5614314d758649ab2ab3a62d4f2004c825922f9e370b29416484086b264ec",
+                "sha256:d920f33822747519673ee656a4b6ac33e382eca9d331c87770faa3eef562aeb2",
+                "sha256:db2b95f9de79181805df90bedc5a5ab4c165e6ec3fe99f970d0e302f384ad222",
+                "sha256:e59e304978767a54663af13c07b3d1af22ddee3bb2fb0618ca1593e4f593a106",
+                "sha256:e85e99945e688e32d5a35c1ff38ed0b3f41f43fad8df0bdf79f72b2ba7bc5272",
+                "sha256:ece47d672db52ac607a3d9599a9d48dcb2f2f735c6c2d1f34130085bb12b112a",
+                "sha256:f4039b9cbc3048b2416cc57ab3bda989a6fcf9b36cf8937f01a6e731b64f80d7"
+            ],
+            "markers": "python_version >= '3.8'",
+            "version": "==2.2.1"
+        }
+    }
+}

--- a/configHelper/README.md
+++ b/configHelper/README.md
@@ -23,3 +23,17 @@ Unit tests can be run from this current `configHelper/` directory by first insta
 pipenv install --dev
 pipenv run test
 ```
+
+### Coverage
+
+_Code coverage_ metrics can be generated after a unit-test run. A report can either be printed on the command line:
+
+```shell
+pipenv run coverage report
+```
+
+or generated as HTML:
+
+```shell
+pipenv run coverage html
+```

--- a/configHelper/README.md
+++ b/configHelper/README.md
@@ -5,7 +5,7 @@ A configuration utility for populating elements of a Jenkins Configuration as Co
 
 To install pipenv:
 ```shell
-pip install pipenv --user
+pip install pipenv
 ```
 
 To use this tool:

--- a/configHelper/README.md
+++ b/configHelper/README.md
@@ -1,0 +1,25 @@
+# CI Config Helper
+A configuration utility for populating elements of a Jenkins Configuration as Code yaml from other sources such as AWS Secrets Manager
+
+## Development
+
+To install pipenv:
+```shell
+pip install pipenv --user
+```
+
+To use this tool:
+
+```shell
+pipenv install
+pipenv run python3 config_helper.py --jenkins-config-file-path=/initial_jenkins.yaml --auth-secret-arn=<SECRET_ARN> --security-realm-id=oic --aws-region=<REGION_NAME>
+```
+
+### Unit Tests
+
+Unit tests can be run from this current `configHelper/` directory by first installing dependencies then running pytest:
+
+```shell
+pipenv install --dev
+pipenv run test
+```

--- a/configHelper/configHelper/config_helper.py
+++ b/configHelper/configHelper/config_helper.py
@@ -46,7 +46,7 @@ def main():
     parser = argparse.ArgumentParser(description="CI config setup helper.")
     parser.add_argument("--initial-jenkins-config-file-path", type=str, required=True, help="The file path for the initial jenkins config yaml file to load from and be modified in place, e.g. /initial_jenkins.yaml")
     parser.add_argument("--auth-aws-secret-arn", type=str, required=True, help="The AWS Secrets Manager Secret ARN to pull auth config from and populate into jenkins config")
-    parser.add_argument("--aws-region", type=str, required=True, help="The AWS region for the boto3 client to use")
+    parser.add_argument("--aws-region", type=str, required=True, help="The AWS region for the boto3 client to use, e.g. us-east-1")
     parser.add_argument("--auth-type", type=str, required=True, help="The Jenkins auth type to use", choices=['oidc', 'github'])
     args = parser.parse_args()
     file_path = args.initial_jenkins_config_file_path

--- a/configHelper/configHelper/config_helper.py
+++ b/configHelper/configHelper/config_helper.py
@@ -35,9 +35,13 @@ def get_secret_as_dict(secret_arn, aws_region):
 def modify_auth_config(yaml_dict, auth_aws_secret_arn, aws_region, auth_type):
     security_realm_id = "oic" if auth_type.lower() == "oidc" else auth_type.lower()
     auth_secret_dict = get_secret_as_dict(auth_aws_secret_arn, aws_region)
+    if "securityRealm" not in yaml_dict.get("jenkins", {}):
+        logging.warning('Unable to find jenkins.securityRealm path in initial Jenkins config yaml, creating securityRealm object')
+        yaml_dict.get("jenkins", {})["securityRealm"] = {}
+    if security_realm_id not in yaml_dict.get("jenkins", {}).get("securityRealm", {}):
+        logging.warning(f'Unable to find jenkins.securityRealm.{security_realm_id} path in initial Jenkins config yaml, creating {security_realm_id} object')
+        yaml_dict.get("jenkins", {}).get("securityRealm", {})[security_realm_id] = {}
     yaml_auth_dict = yaml_dict.get("jenkins", {}).get("securityRealm", {}).get(security_realm_id, {})
-    if not yaml_auth_dict:
-        raise RuntimeError(f'Unable to find jenkins.securityRealm.{security_realm_id} path in initial Jenkins config yaml')
     merge_dicts(yaml_auth_dict, auth_secret_dict)
 
 

--- a/configHelper/configHelper/config_helper.py
+++ b/configHelper/configHelper/config_helper.py
@@ -1,0 +1,76 @@
+import argparse
+import boto3
+import logging
+import json
+import yaml
+
+logging.basicConfig(format='%(asctime)s [%(levelname)s] %(message)s', level=logging.INFO)
+logger = logging.getLogger(__name__)
+
+
+def merge_dicts(dict1, dict2):
+    """Recursively merges two dictionaries."""
+    for key, value in dict2.items():
+        if key in dict1 and isinstance(dict1[key], dict) and isinstance(value, dict):
+            merge_dicts(dict1[key], value)
+        else:
+            dict1[key] = value
+
+def get_secret_as_dict(secret_arn, aws_region):
+    client = boto3.client('secretsmanager', region_name=aws_region)
+    response = client.get_secret_value(SecretId=secret_arn)
+
+    if 'SecretString' in response:
+        secret_string = response['SecretString']
+    else:
+        raise RuntimeError(f'SecretString not found in response when retrieving secret value: {secret_arn}')
+
+    try:
+        secret_dict = json.loads(secret_string)
+    except json.JSONDecodeError as json_error:
+        raise RuntimeError(f"Failed to parse secret string as JSON: {json_error}")
+    return secret_dict
+
+
+def modify_auth_config(yaml_dict, auth_secret_arn, aws_region, security_realm_id):
+    auth_secret_dict = get_secret_as_dict(auth_secret_arn, aws_region)
+    yaml_auth_dict = yaml_dict.get("jenkins", {}).get("securityRealm", {}).get(security_realm_id, {})
+    if not yaml_auth_dict:
+        raise RuntimeError(f'Unable to find jenkins.securityRealm.{security_realm_id} path in initial Jenkins config yaml')
+    merge_dicts(yaml_auth_dict, auth_secret_dict)
+
+
+def main():
+    logging.info("Starting process to load auth config into Jenkins config yaml")
+    parser = argparse.ArgumentParser(description="CI config setup helper.")
+    parser.add_argument("--jenkins-config-file-path", type=str, required=True, help="The file path for the jenkins config yaml file, e.g. /initial_jenkins.yaml")
+    parser.add_argument("--auth-secret-arn", type=str, required=True, help="The AWS Secrets Manager Secret ARN to pull auth config from and populate into jenkins config")
+    parser.add_argument("--aws-region", type=str, required=True, help="The AWS region for the boto3 client to use")
+    parser.add_argument("--security-realm-id", type=str, required=True, help="The Jenkins security realm id to use, e.g. oic,github")
+    args = parser.parse_args()
+    file_path = args.jenkins_config_file_path
+    logging.info(f"The following args were provided: {args}")
+
+    # Read input file data
+    try:
+        with open(file_path, 'r') as file:
+            yaml_data = yaml.safe_load(file)
+    except FileNotFoundError:
+        raise FileNotFoundError(f"Error: The file '{file_path}' does not exist.")
+    except yaml.YAMLError as e:
+        raise ValueError(f"Error parsing YAML file '{file_path}': {e}")
+
+    # Modify input data as needed
+    modify_auth_config(yaml_data, args.auth_secret_arn, args.aws_region, args.security_realm_id)
+
+    # Write file with updated data
+    try:
+        with open(file_path, 'w') as file:
+            yaml.dump(yaml_data, file, default_flow_style=False)
+    except Exception as e:
+        raise IOError(f"Error writing to file '{file_path}': {e}")
+    logging.info("Process completed to load auth config into Jenkins config yaml")
+
+
+if __name__ == "__main__":
+    main()

--- a/configHelper/configHelper/config_helper.py
+++ b/configHelper/configHelper/config_helper.py
@@ -43,7 +43,7 @@ def modify_auth_config(yaml_dict, auth_secret_arn, aws_region, security_realm_id
 def main():
     logging.info("Starting process to load auth config into Jenkins config yaml")
     parser = argparse.ArgumentParser(description="CI config setup helper.")
-    parser.add_argument("--jenkins-config-file-path", type=str, required=True, help="The file path for the jenkins config yaml file, e.g. /initial_jenkins.yaml")
+    parser.add_argument("--initial-jenkins-config-file-path", type=str, required=True, help="The file path for the initial jenkins config yaml file to load from, e.g. /initial_jenkins.yaml")
     parser.add_argument("--auth-secret-arn", type=str, required=True, help="The AWS Secrets Manager Secret ARN to pull auth config from and populate into jenkins config")
     parser.add_argument("--aws-region", type=str, required=True, help="The AWS region for the boto3 client to use")
     parser.add_argument("--security-realm-id", type=str, required=True, help="The Jenkins security realm id to use, e.g. oic,github")

--- a/configHelper/tests/resources/sampleJenkinsGithubAuth.yaml
+++ b/configHelper/tests/resources/sampleJenkinsGithubAuth.yaml
@@ -1,0 +1,253 @@
+jenkins:
+  log:
+    recorders:
+      - loggers:
+          - level: "FINE"
+            name: "org.jenkinsci.plugins.workflow.job.WorkflowRun"
+        name: "workflowRun"
+  agentProtocols:
+    - "JNLP4-connect"
+    - "Ping"
+  authorizationStrategy: "loggedInUsersCanDoAnything"
+  crumbIssuer:
+    standard:
+      excludeClientIPFromCrumb: false
+  disableRememberMe: false
+  labelAtoms:
+    - name: "built-in"
+    - name: "main-node"
+  labelString: "main-node"
+  markupFormatter:
+    rawHtml:
+      disableSyntaxHighlighting: true
+  mode: EXCLUSIVE
+  myViewsTabBar: "standard"
+  numExecutors: 4
+  primaryView:
+    all:
+      name: "all"
+  projectNamingStrategy: "standard"
+  quietPeriod: 5
+  scmCheckoutRetryCount: 0
+  securityRealm:
+    github:
+      githubWebUri: 'https://github.com'
+      githubApiUri: 'https://api.github.com'
+      clientID: 'clientID'
+      clientSecret: 'clientSecret'
+      oauthScopes: 'read:org,user:email'
+  slaveAgentPort: 50000
+  updateCenter:
+    sites:
+      - id: "default"
+        url: "https://updates.jenkins.io/update-center.json"
+  views:
+    - all:
+        name: "all"
+  viewsTabBar: "standard"
+globalCredentialsConfiguration:
+  configuration:
+    providerFilter: "none"
+    typeFilter: "none"
+appearance:
+  loginTheme:
+    useDefaultTheme: true
+security:
+  apiToken:
+    creationOfLegacyTokenEnabled: false
+    tokenGenerationOnCreationEnabled: false
+    usageStatisticsEnabled: true
+  copyartifact:
+    mode: PRODUCTION
+  globalJobDslSecurityConfiguration:
+    useScriptSecurity: true
+  sSHD:
+    port: -1
+unclassified:
+  audit-trail:
+    logBuildCause: true
+    pattern: ".*/(?:configSubmit|doDelete|postBuildResult|enable|disable|cancelQueue|stop|toggleLogKeep|doWipeOutWorkspace|createItem|createView|toggleOffline|cancelQuietDown|quietDown|restart|exit|safeExit)/?.*"
+  awsCredentialsProvider:
+    cache: false
+    client:
+      credentialsProvider: "default"
+  buildDiscarders:
+    configuredBuildDiscarders:
+      - "jobBuildDiscarder"
+  buildStepOperation:
+    enabled: false
+  buildTimestamp:
+    enableBuildTimestamp: true
+    pattern: "yyyy-MM-dd HH:mm:ss z"
+    timezone: "Etc/UTC"
+  descriptionSetterWrapper:
+    disableTokens: false
+  email-ext:
+    adminRequiredForTemplateTesting: false
+    allowUnregisteredEnabled: false
+    charset: "UTF-8"
+    debugMode: false
+    defaultBody: |-
+      $PROJECT_NAME - Build # $BUILD_NUMBER - $BUILD_STATUS:
+
+      Check console output at $BUILD_URL to view the results.
+    defaultSubject: "$PROJECT_NAME - Build # $BUILD_NUMBER - $BUILD_STATUS!"
+    defaultTriggerIds:
+      - "hudson.plugins.emailext.plugins.trigger.FailureTrigger"
+    maxAttachmentSize: -1
+    maxAttachmentSizeMb: -1
+    precedenceBulk: false
+    watchingEnabled: false
+  fingerprints:
+    fingerprintCleanupDisabled: false
+    storage: "file"
+  ghprbTrigger:
+    autoCloseFailedPullRequests: false
+    cron: "H/5 * * * *"
+    extensions:
+      - ghprbSimpleStatus:
+          addTestResults: false
+          showMatrixStatus: false
+    githubAuth:
+      - description: "Anonymous connection"
+        id: "d4456c70-9c5e-4b40-bee4-e1ebb693153b"
+        serverAPIUrl: "https://api.github.com"
+    manageWebhooks: true
+    okToTestPhrase: ".*ok\\W+to\\W+test.*"
+    retestPhrase: ".*test\\W+this\\W+please.*"
+    skipBuildPhrase: ".*\\[skip\\W+ci\\].*"
+    useComments: false
+    useDetailedComments: false
+    whitelistPhrase: ".*add\\W+to\\W+whitelist.*"
+  gitHubConfiguration:
+    apiRateLimitChecker: ThrottleForNormalize
+  gitHubPluginConfig:
+    hookUrl: "http://localhost:8080/github-webhook/"
+  scmGit:
+    addGitTagAction: false
+    allowSecondFetch: false
+    createAccountBasedOnEmail: false
+    disableGitToolChooser: false
+    hideCredentials: false
+    showEntireCommitSummaryInChanges: false
+    useExistingAccountWithSameEmail: false
+  ivyBuildTrigger:
+    extendedVersionMatching: false
+  junitTestResultStorage:
+    storage: "file"
+  location:
+    adminAddress: "address not configured yet <nobody@nowhere>"
+  mailer:
+    charset: "UTF-8"
+    useSsl: false
+    useTls: false
+  pollSCM:
+    pollingThreadCount: 10
+  timestamper:
+    allPipelines: false
+    elapsedTimeFormat: "'<b>'HH:mm:ss.S'</b> '"
+    systemTimeFormat: "'<b>'HH:mm:ss'</b> '"
+  upstream:
+    globalUpstreamFilterStrategy: UseOldest
+  whitelist:
+    enabled: false
+tool:
+  git:
+    installations:
+      - home: "git"
+        name: "Default"
+  jdk:
+    installations:
+      - name: "openjdk-8"
+        properties:
+          - installSource:
+              installers:
+                - adoptOpenJdkInstaller:
+                    id: "jdk8u332-b09"
+      - name: "openjdk-11"
+        properties:
+          - installSource:
+              installers:
+                - adoptOpenJdkInstaller:
+                    id: "jdk-11.0.15+10"
+      - name: "openjdk-17"
+        properties:
+          - installSource:
+              installers:
+                - adoptOpenJdkInstaller:
+                    id: "jdk-17.0.3+7"
+      - name: "openjdk-19"
+        properties:
+          - installSource:
+              installers:
+                - adoptOpenJdkInstaller:
+                    id: "jdk-19.0.1+10"
+      - name: "openjdk-20"
+        properties:
+          - installSource:
+              installers:
+                - adoptOpenJdkInstaller:
+                    id: "jdk-20.0.1+9"
+      - name: "openjdk-21"
+        properties:
+          - installSource:
+              installers:
+                - adoptOpenJdkInstaller:
+                    id: "jdk-21.0.1+12"
+  mavenGlobalConfig:
+    globalSettingsProvider: "standard"
+    settingsProvider: "standard"
+  powerShellInstallation:
+    installations:
+      - home: "powershell.exe"
+        name: "DefaultWindows"
+      - home: "pwsh"
+        name: "DefaultLinux"
+support:
+  automatedBundleConfiguration:
+    componentIds:
+      - "AgentsConfigFile"
+      - "ConfigFileComponent"
+      - "OtherConfigFilesComponent"
+      - "AboutBrowser"
+      - "AboutJenkins"
+      - "AboutUser"
+      - "AdministrativeMonitors"
+      - "AgentProtocols"
+      - "BuildQueue"
+      - "CustomLogs"
+      - "DumpExportTable"
+      - "EnvironmentVariables"
+      - "FileDescriptorLimit"
+      - "GCLogs"
+      - "HeapUsageHistogram"
+      - "ItemsContent"
+      - "AgentsJVMProcessSystemMetricsContents"
+      - "MasterJVMProcessSystemMetricsContents"
+      - "JenkinsLogs"
+      - "LoadStats"
+      - "LoggerManager"
+      - "Metrics"
+      - "NetworkInterfaces"
+      - "NodeMonitors"
+      - "OtherLogs"
+      - "ReverseProxy"
+      - "RootCAs"
+      - "RunningBuilds"
+      - "SlaveCommandStatistics"
+      - "SlaveLaunchLogs"
+      - "SlaveLogs"
+      - "AgentsSystemConfiguration"
+      - "MasterSystemConfiguration"
+      - "SystemProperties"
+      - "TaskLogs"
+      - "ThreadDumps"
+      - "UpdateCenter"
+      - "UserCount"
+      - "SlowRequestComponent"
+      - "HighLoadComponent"
+      - "DeadlockRequestComponent"
+      - "PipelineTimings"
+      - "PipelineThreadDump"
+    enabled: true
+    period: 1

--- a/configHelper/tests/resources/sampleJenkinsNoSecurityRealm.yaml
+++ b/configHelper/tests/resources/sampleJenkinsNoSecurityRealm.yaml
@@ -1,0 +1,246 @@
+jenkins:
+  log:
+    recorders:
+      - loggers:
+          - level: "FINE"
+            name: "org.jenkinsci.plugins.workflow.job.WorkflowRun"
+        name: "workflowRun"
+  agentProtocols:
+    - "JNLP4-connect"
+    - "Ping"
+  authorizationStrategy: "loggedInUsersCanDoAnything"
+  crumbIssuer:
+    standard:
+      excludeClientIPFromCrumb: false
+  disableRememberMe: false
+  labelAtoms:
+    - name: "built-in"
+    - name: "main-node"
+  labelString: "main-node"
+  markupFormatter:
+    rawHtml:
+      disableSyntaxHighlighting: true
+  mode: EXCLUSIVE
+  myViewsTabBar: "standard"
+  numExecutors: 4
+  primaryView:
+    all:
+      name: "all"
+  projectNamingStrategy: "standard"
+  quietPeriod: 5
+  scmCheckoutRetryCount: 0
+  slaveAgentPort: 50000
+  updateCenter:
+    sites:
+      - id: "default"
+        url: "https://updates.jenkins.io/update-center.json"
+  views:
+    - all:
+        name: "all"
+  viewsTabBar: "standard"
+globalCredentialsConfiguration:
+  configuration:
+    providerFilter: "none"
+    typeFilter: "none"
+appearance:
+  loginTheme:
+    useDefaultTheme: true
+security:
+  apiToken:
+    creationOfLegacyTokenEnabled: false
+    tokenGenerationOnCreationEnabled: false
+    usageStatisticsEnabled: true
+  copyartifact:
+    mode: PRODUCTION
+  globalJobDslSecurityConfiguration:
+    useScriptSecurity: true
+  sSHD:
+    port: -1
+unclassified:
+  audit-trail:
+    logBuildCause: true
+    pattern: ".*/(?:configSubmit|doDelete|postBuildResult|enable|disable|cancelQueue|stop|toggleLogKeep|doWipeOutWorkspace|createItem|createView|toggleOffline|cancelQuietDown|quietDown|restart|exit|safeExit)/?.*"
+  awsCredentialsProvider:
+    cache: false
+    client:
+      credentialsProvider: "default"
+  buildDiscarders:
+    configuredBuildDiscarders:
+      - "jobBuildDiscarder"
+  buildStepOperation:
+    enabled: false
+  buildTimestamp:
+    enableBuildTimestamp: true
+    pattern: "yyyy-MM-dd HH:mm:ss z"
+    timezone: "Etc/UTC"
+  descriptionSetterWrapper:
+    disableTokens: false
+  email-ext:
+    adminRequiredForTemplateTesting: false
+    allowUnregisteredEnabled: false
+    charset: "UTF-8"
+    debugMode: false
+    defaultBody: |-
+      $PROJECT_NAME - Build # $BUILD_NUMBER - $BUILD_STATUS:
+
+      Check console output at $BUILD_URL to view the results.
+    defaultSubject: "$PROJECT_NAME - Build # $BUILD_NUMBER - $BUILD_STATUS!"
+    defaultTriggerIds:
+      - "hudson.plugins.emailext.plugins.trigger.FailureTrigger"
+    maxAttachmentSize: -1
+    maxAttachmentSizeMb: -1
+    precedenceBulk: false
+    watchingEnabled: false
+  fingerprints:
+    fingerprintCleanupDisabled: false
+    storage: "file"
+  ghprbTrigger:
+    autoCloseFailedPullRequests: false
+    cron: "H/5 * * * *"
+    extensions:
+      - ghprbSimpleStatus:
+          addTestResults: false
+          showMatrixStatus: false
+    githubAuth:
+      - description: "Anonymous connection"
+        id: "d4456c70-9c5e-4b40-bee4-e1ebb693153b"
+        serverAPIUrl: "https://api.github.com"
+    manageWebhooks: true
+    okToTestPhrase: ".*ok\\W+to\\W+test.*"
+    retestPhrase: ".*test\\W+this\\W+please.*"
+    skipBuildPhrase: ".*\\[skip\\W+ci\\].*"
+    useComments: false
+    useDetailedComments: false
+    whitelistPhrase: ".*add\\W+to\\W+whitelist.*"
+  gitHubConfiguration:
+    apiRateLimitChecker: ThrottleForNormalize
+  gitHubPluginConfig:
+    hookUrl: "http://localhost:8080/github-webhook/"
+  scmGit:
+    addGitTagAction: false
+    allowSecondFetch: false
+    createAccountBasedOnEmail: false
+    disableGitToolChooser: false
+    hideCredentials: false
+    showEntireCommitSummaryInChanges: false
+    useExistingAccountWithSameEmail: false
+  ivyBuildTrigger:
+    extendedVersionMatching: false
+  junitTestResultStorage:
+    storage: "file"
+  location:
+    adminAddress: "address not configured yet <nobody@nowhere>"
+  mailer:
+    charset: "UTF-8"
+    useSsl: false
+    useTls: false
+  pollSCM:
+    pollingThreadCount: 10
+  timestamper:
+    allPipelines: false
+    elapsedTimeFormat: "'<b>'HH:mm:ss.S'</b> '"
+    systemTimeFormat: "'<b>'HH:mm:ss'</b> '"
+  upstream:
+    globalUpstreamFilterStrategy: UseOldest
+  whitelist:
+    enabled: false
+tool:
+  git:
+    installations:
+      - home: "git"
+        name: "Default"
+  jdk:
+    installations:
+      - name: "openjdk-8"
+        properties:
+          - installSource:
+              installers:
+                - adoptOpenJdkInstaller:
+                    id: "jdk8u332-b09"
+      - name: "openjdk-11"
+        properties:
+          - installSource:
+              installers:
+                - adoptOpenJdkInstaller:
+                    id: "jdk-11.0.15+10"
+      - name: "openjdk-17"
+        properties:
+          - installSource:
+              installers:
+                - adoptOpenJdkInstaller:
+                    id: "jdk-17.0.3+7"
+      - name: "openjdk-19"
+        properties:
+          - installSource:
+              installers:
+                - adoptOpenJdkInstaller:
+                    id: "jdk-19.0.1+10"
+      - name: "openjdk-20"
+        properties:
+          - installSource:
+              installers:
+                - adoptOpenJdkInstaller:
+                    id: "jdk-20.0.1+9"
+      - name: "openjdk-21"
+        properties:
+          - installSource:
+              installers:
+                - adoptOpenJdkInstaller:
+                    id: "jdk-21.0.1+12"
+  mavenGlobalConfig:
+    globalSettingsProvider: "standard"
+    settingsProvider: "standard"
+  powerShellInstallation:
+    installations:
+      - home: "powershell.exe"
+        name: "DefaultWindows"
+      - home: "pwsh"
+        name: "DefaultLinux"
+support:
+  automatedBundleConfiguration:
+    componentIds:
+      - "AgentsConfigFile"
+      - "ConfigFileComponent"
+      - "OtherConfigFilesComponent"
+      - "AboutBrowser"
+      - "AboutJenkins"
+      - "AboutUser"
+      - "AdministrativeMonitors"
+      - "AgentProtocols"
+      - "BuildQueue"
+      - "CustomLogs"
+      - "DumpExportTable"
+      - "EnvironmentVariables"
+      - "FileDescriptorLimit"
+      - "GCLogs"
+      - "HeapUsageHistogram"
+      - "ItemsContent"
+      - "AgentsJVMProcessSystemMetricsContents"
+      - "MasterJVMProcessSystemMetricsContents"
+      - "JenkinsLogs"
+      - "LoadStats"
+      - "LoggerManager"
+      - "Metrics"
+      - "NetworkInterfaces"
+      - "NodeMonitors"
+      - "OtherLogs"
+      - "ReverseProxy"
+      - "RootCAs"
+      - "RunningBuilds"
+      - "SlaveCommandStatistics"
+      - "SlaveLaunchLogs"
+      - "SlaveLogs"
+      - "AgentsSystemConfiguration"
+      - "MasterSystemConfiguration"
+      - "SystemProperties"
+      - "TaskLogs"
+      - "ThreadDumps"
+      - "UpdateCenter"
+      - "UserCount"
+      - "SlowRequestComponent"
+      - "HighLoadComponent"
+      - "DeadlockRequestComponent"
+      - "PipelineTimings"
+      - "PipelineThreadDump"
+    enabled: true
+    period: 1

--- a/configHelper/tests/resources/sampleJenkinsOICAuth.yaml
+++ b/configHelper/tests/resources/sampleJenkinsOICAuth.yaml
@@ -39,6 +39,7 @@ jenkins:
       logoutFromOpenidProvider: true
       postLogoutRedirectUrl: ''
       escapeHatchSecret: random
+      serverConfiguration: {}
   slaveAgentPort: 50000
   updateCenter:
     sites:

--- a/configHelper/tests/resources/sampleJenkinsOICAuth.yaml
+++ b/configHelper/tests/resources/sampleJenkinsOICAuth.yaml
@@ -1,0 +1,260 @@
+jenkins:
+  log:
+    recorders:
+      - loggers:
+          - level: "FINE"
+            name: "org.jenkinsci.plugins.workflow.job.WorkflowRun"
+        name: "workflowRun"
+  agentProtocols:
+    - "JNLP4-connect"
+    - "Ping"
+  authorizationStrategy: "loggedInUsersCanDoAnything"
+  crumbIssuer:
+    standard:
+      excludeClientIPFromCrumb: false
+  disableRememberMe: false
+  labelAtoms:
+    - name: "built-in"
+    - name: "main-node"
+  labelString: "main-node"
+  markupFormatter:
+    rawHtml:
+      disableSyntaxHighlighting: true
+  mode: EXCLUSIVE
+  myViewsTabBar: "standard"
+  numExecutors: 4
+  primaryView:
+    all:
+      name: "all"
+  projectNamingStrategy: "standard"
+  quietPeriod: 5
+  scmCheckoutRetryCount: 0
+  securityRealm:
+    oic:
+      clientId: example_id
+      clientSecret: example_password
+      disableSslVerification: false
+      userNameField: sub
+      escapeHatchEnabled: false
+      logoutFromOpenidProvider: true
+      postLogoutRedirectUrl: ''
+      escapeHatchSecret: random
+      serverConfiguration:
+        wellKnown:
+          scopes: open-id
+          wellKnownOpenIDConfigurationUrl: https://localhost
+  slaveAgentPort: 50000
+  updateCenter:
+    sites:
+      - id: "default"
+        url: "https://updates.jenkins.io/update-center.json"
+  views:
+    - all:
+        name: "all"
+  viewsTabBar: "standard"
+globalCredentialsConfiguration:
+  configuration:
+    providerFilter: "none"
+    typeFilter: "none"
+appearance:
+  loginTheme:
+    useDefaultTheme: true
+security:
+  apiToken:
+    creationOfLegacyTokenEnabled: false
+    tokenGenerationOnCreationEnabled: false
+    usageStatisticsEnabled: true
+  copyartifact:
+    mode: PRODUCTION
+  globalJobDslSecurityConfiguration:
+    useScriptSecurity: true
+  sSHD:
+    port: -1
+unclassified:
+  audit-trail:
+    logBuildCause: true
+    pattern: ".*/(?:configSubmit|doDelete|postBuildResult|enable|disable|cancelQueue|stop|toggleLogKeep|doWipeOutWorkspace|createItem|createView|toggleOffline|cancelQuietDown|quietDown|restart|exit|safeExit)/?.*"
+  awsCredentialsProvider:
+    cache: false
+    client:
+      credentialsProvider: "default"
+  buildDiscarders:
+    configuredBuildDiscarders:
+      - "jobBuildDiscarder"
+  buildStepOperation:
+    enabled: false
+  buildTimestamp:
+    enableBuildTimestamp: true
+    pattern: "yyyy-MM-dd HH:mm:ss z"
+    timezone: "Etc/UTC"
+  descriptionSetterWrapper:
+    disableTokens: false
+  email-ext:
+    adminRequiredForTemplateTesting: false
+    allowUnregisteredEnabled: false
+    charset: "UTF-8"
+    debugMode: false
+    defaultBody: |-
+      $PROJECT_NAME - Build # $BUILD_NUMBER - $BUILD_STATUS:
+
+      Check console output at $BUILD_URL to view the results.
+    defaultSubject: "$PROJECT_NAME - Build # $BUILD_NUMBER - $BUILD_STATUS!"
+    defaultTriggerIds:
+      - "hudson.plugins.emailext.plugins.trigger.FailureTrigger"
+    maxAttachmentSize: -1
+    maxAttachmentSizeMb: -1
+    precedenceBulk: false
+    watchingEnabled: false
+  fingerprints:
+    fingerprintCleanupDisabled: false
+    storage: "file"
+  ghprbTrigger:
+    autoCloseFailedPullRequests: false
+    cron: "H/5 * * * *"
+    extensions:
+      - ghprbSimpleStatus:
+          addTestResults: false
+          showMatrixStatus: false
+    githubAuth:
+      - description: "Anonymous connection"
+        id: "d4456c70-9c5e-4b40-bee4-e1ebb693153b"
+        serverAPIUrl: "https://api.github.com"
+    manageWebhooks: true
+    okToTestPhrase: ".*ok\\W+to\\W+test.*"
+    retestPhrase: ".*test\\W+this\\W+please.*"
+    skipBuildPhrase: ".*\\[skip\\W+ci\\].*"
+    useComments: false
+    useDetailedComments: false
+    whitelistPhrase: ".*add\\W+to\\W+whitelist.*"
+  gitHubConfiguration:
+    apiRateLimitChecker: ThrottleForNormalize
+  gitHubPluginConfig:
+    hookUrl: "http://localhost:8080/github-webhook/"
+  scmGit:
+    addGitTagAction: false
+    allowSecondFetch: false
+    createAccountBasedOnEmail: false
+    disableGitToolChooser: false
+    hideCredentials: false
+    showEntireCommitSummaryInChanges: false
+    useExistingAccountWithSameEmail: false
+  ivyBuildTrigger:
+    extendedVersionMatching: false
+  junitTestResultStorage:
+    storage: "file"
+  location:
+    adminAddress: "address not configured yet <nobody@nowhere>"
+  mailer:
+    charset: "UTF-8"
+    useSsl: false
+    useTls: false
+  pollSCM:
+    pollingThreadCount: 10
+  timestamper:
+    allPipelines: false
+    elapsedTimeFormat: "'<b>'HH:mm:ss.S'</b> '"
+    systemTimeFormat: "'<b>'HH:mm:ss'</b> '"
+  upstream:
+    globalUpstreamFilterStrategy: UseOldest
+  whitelist:
+    enabled: false
+tool:
+  git:
+    installations:
+      - home: "git"
+        name: "Default"
+  jdk:
+    installations:
+      - name: "openjdk-8"
+        properties:
+          - installSource:
+              installers:
+                - adoptOpenJdkInstaller:
+                    id: "jdk8u332-b09"
+      - name: "openjdk-11"
+        properties:
+          - installSource:
+              installers:
+                - adoptOpenJdkInstaller:
+                    id: "jdk-11.0.15+10"
+      - name: "openjdk-17"
+        properties:
+          - installSource:
+              installers:
+                - adoptOpenJdkInstaller:
+                    id: "jdk-17.0.3+7"
+      - name: "openjdk-19"
+        properties:
+          - installSource:
+              installers:
+                - adoptOpenJdkInstaller:
+                    id: "jdk-19.0.1+10"
+      - name: "openjdk-20"
+        properties:
+          - installSource:
+              installers:
+                - adoptOpenJdkInstaller:
+                    id: "jdk-20.0.1+9"
+      - name: "openjdk-21"
+        properties:
+          - installSource:
+              installers:
+                - adoptOpenJdkInstaller:
+                    id: "jdk-21.0.1+12"
+  mavenGlobalConfig:
+    globalSettingsProvider: "standard"
+    settingsProvider: "standard"
+  powerShellInstallation:
+    installations:
+      - home: "powershell.exe"
+        name: "DefaultWindows"
+      - home: "pwsh"
+        name: "DefaultLinux"
+support:
+  automatedBundleConfiguration:
+    componentIds:
+      - "AgentsConfigFile"
+      - "ConfigFileComponent"
+      - "OtherConfigFilesComponent"
+      - "AboutBrowser"
+      - "AboutJenkins"
+      - "AboutUser"
+      - "AdministrativeMonitors"
+      - "AgentProtocols"
+      - "BuildQueue"
+      - "CustomLogs"
+      - "DumpExportTable"
+      - "EnvironmentVariables"
+      - "FileDescriptorLimit"
+      - "GCLogs"
+      - "HeapUsageHistogram"
+      - "ItemsContent"
+      - "AgentsJVMProcessSystemMetricsContents"
+      - "MasterJVMProcessSystemMetricsContents"
+      - "JenkinsLogs"
+      - "LoadStats"
+      - "LoggerManager"
+      - "Metrics"
+      - "NetworkInterfaces"
+      - "NodeMonitors"
+      - "OtherLogs"
+      - "ReverseProxy"
+      - "RootCAs"
+      - "RunningBuilds"
+      - "SlaveCommandStatistics"
+      - "SlaveLaunchLogs"
+      - "SlaveLogs"
+      - "AgentsSystemConfiguration"
+      - "MasterSystemConfiguration"
+      - "SystemProperties"
+      - "TaskLogs"
+      - "ThreadDumps"
+      - "UpdateCenter"
+      - "UserCount"
+      - "SlowRequestComponent"
+      - "HighLoadComponent"
+      - "DeadlockRequestComponent"
+      - "PipelineTimings"
+      - "PipelineThreadDump"
+    enabled: true
+    period: 1

--- a/configHelper/tests/resources/sampleJenkinsOICAuth.yaml
+++ b/configHelper/tests/resources/sampleJenkinsOICAuth.yaml
@@ -39,10 +39,6 @@ jenkins:
       logoutFromOpenidProvider: true
       postLogoutRedirectUrl: ''
       escapeHatchSecret: random
-      serverConfiguration:
-        wellKnown:
-          scopes: open-id
-          wellKnownOpenIDConfigurationUrl: https://localhost
   slaveAgentPort: 50000
   updateCenter:
     sites:

--- a/configHelper/tests/test_config_helper.py
+++ b/configHelper/tests/test_config_helper.py
@@ -5,7 +5,6 @@ import shutil
 import yaml
 
 TEST_RESOURCES_PATH = f"{Path(__file__).parents[1]}/tests/resources"
-GEN_TEST_RESOURCES_PATH = f"{Path(__file__).parents[1]}/tests/resources/generated"
 MOCK_OIDC_SECRET = """
 {
     "clientId":"test.pytest.id",
@@ -41,9 +40,9 @@ def test_valid_oidc_auth_config(tmp_path):
     source_jenkins_file_path = f"{TEST_RESOURCES_PATH}/sampleJenkinsOICAuth.yaml"
     tmp_file_path = f"{tmp_path}/oicAuthTestJenkins.yaml"
     shutil.copy(source_jenkins_file_path, tmp_file_path)
-    with (patch("sys.argv", ["config_helper.py", f"--jenkins-config-file-path={tmp_file_path}",
-                            "--auth-secret-arn=arn:aws:secretsmanager:123456789012:secret/test-secret",
-                            "--security-realm-id=oic",
+    with (patch("sys.argv", ["config_helper.py", f"--initial-jenkins-config-file-path={tmp_file_path}",
+                            "--auth-aws-secret-arn=arn:aws:secretsmanager:123456789012:secret/test-secret",
+                            "--auth-type=oidc",
                              "--aws-region=us-east-1"]),
           patch("boto3.client") as mock_boto_client):
             # Mock the get_secret_value call
@@ -76,9 +75,9 @@ def test_valid_github_auth_config(tmp_path):
     source_jenkins_file_path = f"{TEST_RESOURCES_PATH}/sampleJenkinsGithubAuth.yaml"
     tmp_file_path = f"{tmp_path}/githubAuthTestJenkins.yaml"
     shutil.copy(source_jenkins_file_path, tmp_file_path)
-    with (patch("sys.argv", ["config_helper.py", f"--jenkins-config-file-path={tmp_file_path}",
-                             "--auth-secret-arn=arn:aws:secretsmanager:123456789012:secret/test-secret",
-                             "--security-realm-id=github",
+    with (patch("sys.argv", ["config_helper.py", f"--initial-jenkins-config-file-path={tmp_file_path}",
+                             "--auth-aws-secret-arn=arn:aws:secretsmanager:123456789012:secret/test-secret",
+                             "--auth-type=github",
                              "--aws-region=us-east-1"]),
           patch("boto3.client") as mock_boto_client):
         # Mock the get_secret_value call

--- a/configHelper/tests/test_config_helper.py
+++ b/configHelper/tests/test_config_helper.py
@@ -64,7 +64,6 @@ def test_valid_oidc_auth_config(tmp_path):
         "userNameField": "sub",
         "serverConfiguration": {
             "wellKnown": {
-                "scopes": "open-id",
                 "wellKnownOpenIDConfigurationUrl": "https://my.openid-config.com"
             }
         }

--- a/configHelper/tests/test_config_helper.py
+++ b/configHelper/tests/test_config_helper.py
@@ -1,0 +1,99 @@
+from configHelper.config_helper import main
+from pathlib import Path
+from unittest.mock import patch
+import shutil
+import yaml
+
+TEST_RESOURCES_PATH = f"{Path(__file__).parents[1]}/tests/resources"
+GEN_TEST_RESOURCES_PATH = f"{Path(__file__).parents[1]}/tests/resources/generated"
+MOCK_OIDC_SECRET = """
+{
+    "clientId":"test.pytest.id",
+    "clientSecret":"tyuuyohjk34jasdfOPPOEW",
+    "serverConfiguration": {
+        "wellKnown": {
+            "wellKnownOpenIDConfigurationUrl": "https://my.openid-config.com"
+        }
+    }
+}
+"""
+MOCK_GITHUB_SECRET = """
+{
+    "clientID":"test.pytest.id",
+    "clientSecret":"tyuuyohjk34jasdfOPPOEW"
+}
+"""
+
+def compare_yaml_files_security_realm_updates(intial_config_file, updated_config_file, expected_security_realm_config, security_realm_id):
+    with open(intial_config_file, 'r') as f1, open(updated_config_file, 'r') as f2:
+        initial_data = yaml.safe_load(f1)
+        updated_data = yaml.safe_load(f2)
+        initial_data_security_realm = initial_data.get("jenkins", {}).get("securityRealm", {}).get(security_realm_id, {})
+        assert initial_data_security_realm == expected_security_realm_config
+        # Ensure other values besides security realm have not changed
+        initial_data.get("jenkins", {}).get("securityRealm", {}).get(security_realm_id, {}).clear()
+        updated_data.get("jenkins", {}).get("securityRealm", {}).get(security_realm_id, {}).clear()
+        assert initial_data == updated_data
+
+
+def test_valid_oidc_auth_config(tmp_path):
+    # tmp_path fixture cleans up any files in its directory automatically after test execution
+    source_jenkins_file_path = f"{TEST_RESOURCES_PATH}/sampleJenkinsOICAuth.yaml"
+    tmp_file_path = f"{tmp_path}/oicAuthTestJenkins.yaml"
+    shutil.copy(source_jenkins_file_path, tmp_file_path)
+    with (patch("sys.argv", ["config_helper.py", f"--jenkins-config-file-path={tmp_file_path}",
+                            "--auth-secret-arn=arn:aws:secretsmanager:123456789012:secret/test-secret",
+                            "--security-realm-id=oic",
+                             "--aws-region=us-east-1"]),
+          patch("boto3.client") as mock_boto_client):
+            # Mock the get_secret_value call
+            mock_client_instance = mock_boto_client.return_value
+            mock_client_instance.get_secret_value.return_value = {
+                "SecretString": MOCK_OIDC_SECRET
+            }
+            main()
+    # Expected is merge of source jenkins file and mock oidc secret values
+    expected_oic_auth_dict = {
+        "clientId": "test.pytest.id",
+        "clientSecret": "tyuuyohjk34jasdfOPPOEW",
+        "disableSslVerification": False,
+        "escapeHatchEnabled": False,
+        "logoutFromOpenidProvider": True,
+        "postLogoutRedirectUrl": "",
+        "escapeHatchSecret": "random",
+        "userNameField": "sub",
+        "serverConfiguration": {
+            "wellKnown": {
+                "scopes": "open-id",
+                "wellKnownOpenIDConfigurationUrl": "https://my.openid-config.com"
+            }
+        }
+    }
+    compare_yaml_files_security_realm_updates(tmp_file_path, source_jenkins_file_path, expected_oic_auth_dict, "oic")
+
+
+def test_valid_github_auth_config(tmp_path):
+    # tmp_path fixture cleans up any files in its directory automatically after test execution
+    source_jenkins_file_path = f"{TEST_RESOURCES_PATH}/sampleJenkinsGithubAuth.yaml"
+    tmp_file_path = f"{tmp_path}/githubAuthTestJenkins.yaml"
+    shutil.copy(source_jenkins_file_path, tmp_file_path)
+    with (patch("sys.argv", ["config_helper.py", f"--jenkins-config-file-path={tmp_file_path}",
+                             "--auth-secret-arn=arn:aws:secretsmanager:123456789012:secret/test-secret",
+                             "--security-realm-id=github",
+                             "--aws-region=us-east-1"]),
+          patch("boto3.client") as mock_boto_client):
+        # Mock the get_secret_value call
+        mock_client_instance = mock_boto_client.return_value
+        mock_client_instance.get_secret_value.return_value = {
+            "SecretString": MOCK_GITHUB_SECRET
+        }
+        main()
+    # Expected is merge of source jenkins file and mock github auth secret values
+    expected_github_auth_dict = {
+        "clientID": "test.pytest.id",
+        "clientSecret": "tyuuyohjk34jasdfOPPOEW",
+        "githubWebUri": "https://github.com",
+        "githubApiUri": "https://api.github.com",
+        "oauthScopes": "read:org,user:email"
+    }
+    compare_yaml_files_security_realm_updates(tmp_file_path, source_jenkins_file_path, expected_github_auth_dict, "github")

--- a/lib/compute/auth-config.ts
+++ b/lib/compute/auth-config.ts
@@ -81,17 +81,13 @@ export class AuthConfig {
       oic: {
         clientId: 'clientId',
         clientSecret: 'clientSecret',
-        authorizationServerUrl: 'http://localhost',
-        wellKnownOpenIDConfigurationUrl: 'wellKnownOpenIDConfigurationUrl',
-        tokenServerUrl: 'tokenServerUrl',
-        userInfoServerUrl: 'userInfoServerUrl',
         disableSslVerification: false,
         userNameField: 'sub',
         escapeHatchEnabled: false,
         logoutFromOpenidProvider: true,
         postLogoutRedirectUrl: '',
-        scopes: 'openid',
         escapeHatchSecret: 'random',
+        serverConfiguration: {},
       },
     };
 

--- a/lib/compute/auth-config.ts
+++ b/lib/compute/auth-config.ts
@@ -87,6 +87,7 @@ export class AuthConfig {
         logoutFromOpenidProvider: true,
         postLogoutRedirectUrl: '',
         escapeHatchSecret: 'random',
+        serverConfiguration: {},
       },
     };
 

--- a/lib/compute/auth-config.ts
+++ b/lib/compute/auth-config.ts
@@ -87,7 +87,6 @@ export class AuthConfig {
         logoutFromOpenidProvider: true,
         postLogoutRedirectUrl: '',
         escapeHatchSecret: 'random',
-        serverConfiguration: {},
       },
     };
 

--- a/lib/compute/jenkins-main-node.ts
+++ b/lib/compute/jenkins-main-node.ts
@@ -232,12 +232,6 @@ export class JenkinsMainNode {
   public static configElements(stackName: string, stackRegion: string, httpConfigProps: HttpConfigProps,
     loginAuthProps: LoginAuthProps, dataRetentionProps: DataRetentionProps, jenkinsyaml: string,
     reloadPasswordSecretsArn: string, efsId?: string): InitElement[] {
-    let realm = '';
-    if (loginAuthProps.authType === 'github') {
-      realm = 'github';
-    } else if (loginAuthProps.authType === 'oidc') {
-      realm = 'oic';
-    }
     return [
       InitPackage.yum('wget'),
       InitPackage.yum('cronie'),
@@ -437,7 +431,7 @@ export class JenkinsMainNode {
       // Make any changes to initial jenkins.yaml
       InitCommand.shellCommand(loginAuthProps.authType !== 'default'
         // eslint-disable-next-line max-len
-        ? `cd /configHelper && sudo pipenv run python3 config_helper.py --jenkins-config-file-path=/initial_jenkins.yaml --auth-secret-arn=${loginAuthProps.authCredsSecretsArn} --security-realm-id=${realm} --aws-region=${stackRegion} > configHelper.log 2>&1`
+        ? `cd /configHelper && sudo pipenv run python3 config_helper.py --initial-jenkins-config-file-path=/initial_jenkins.yaml --auth-aws-secret-arn=${loginAuthProps.authCredsSecretsArn} --auth-type=${loginAuthProps.authType} --aws-region=${stackRegion} > configHelper.log 2>&1`
         : 'No changes made to initial_jenkins.yaml with respect to AuthType'),
       InitCommand.shellCommand('while [[ "$(curl -s -o /dev/null -w \'\'%{http_code}\'\' localhost:8080/api/json?pretty)" != "200" ]]; do sleep 5; done'),
 

--- a/lib/compute/jenkins-main-node.ts
+++ b/lib/compute/jenkins-main-node.ts
@@ -249,7 +249,7 @@ export class JenkinsMainNode {
       InitPackage.yum('python3-pip.noarch'),
       InitPackage.yum('java-11-amazon-corretto'),
       InitCommand.shellCommand('pip3 install botocore'),
-      InitCommand.shellCommand('cd / && pip3 install --ignore-installed setuptools && pip3 install pipenv'),
+      InitCommand.shellCommand('pip3 install --ignore-installed setuptools && pip3 install pipenv'),
       InitCommand.shellCommand('systemctl enable crond.service'),
       InitCommand.shellCommand('systemctl start crond.service'),
       // eslint-disable-next-line max-len

--- a/lib/compute/jenkins-main-node.ts
+++ b/lib/compute/jenkins-main-node.ts
@@ -438,7 +438,7 @@ export class JenkinsMainNode {
       InitCommand.shellCommand(loginAuthProps.authType !== 'default'
         // eslint-disable-next-line max-len
         ? `cd /configHelper && sudo pipenv run python3 config_helper.py --jenkins-config-file-path=/initial_jenkins.yaml --auth-secret-arn=${loginAuthProps.authCredsSecretsArn} --security-realm-id=${realm} --aws-region=${stackRegion} > configHelper.log 2>&1`
-        : 'No changes made to initial_jenkins.yaml with respect to OIDC'),
+        : 'No changes made to initial_jenkins.yaml with respect to AuthType'),
       InitCommand.shellCommand('while [[ "$(curl -s -o /dev/null -w \'\'%{http_code}\'\' localhost:8080/api/json?pretty)" != "200" ]]; do sleep 5; done'),
 
       // Reload configuration via Jenkins.yaml

--- a/test/compute/auth-config.test.ts
+++ b/test/compute/auth-config.test.ts
@@ -22,6 +22,7 @@ describe('Test authType OIDC', () => {
     logoutFromOpenidProvider: true,
     postLogoutRedirectUrl: '',
     escapeHatchSecret: 'random',
+    serverConfiguration: {},
   };
   const admins = ['admin1', 'admin2'];
   const yml : any = load(readFileSync(JenkinsMainNode.BASE_JENKINS_YAML_PATH, 'utf-8'));

--- a/test/compute/auth-config.test.ts
+++ b/test/compute/auth-config.test.ts
@@ -16,17 +16,13 @@ describe('Test authType OIDC', () => {
   const oidcConfig = {
     clientId: 'clientId',
     clientSecret: 'clientSecret',
-    authorizationServerUrl: 'http://localhost',
-    wellKnownOpenIDConfigurationUrl: 'wellKnownOpenIDConfigurationUrl',
-    tokenServerUrl: 'tokenServerUrl',
-    userInfoServerUrl: 'userInfoServerUrl',
     disableSslVerification: false,
     userNameField: 'sub',
     escapeHatchEnabled: false,
     logoutFromOpenidProvider: true,
     postLogoutRedirectUrl: '',
-    scopes: 'openid',
     escapeHatchSecret: 'random',
+    serverConfiguration: {},
   };
   const admins = ['admin1', 'admin2'];
   const yml : any = load(readFileSync(JenkinsMainNode.BASE_JENKINS_YAML_PATH, 'utf-8'));

--- a/test/compute/auth-config.test.ts
+++ b/test/compute/auth-config.test.ts
@@ -22,7 +22,6 @@ describe('Test authType OIDC', () => {
     logoutFromOpenidProvider: true,
     postLogoutRedirectUrl: '',
     escapeHatchSecret: 'random',
-    serverConfiguration: {},
   };
   const admins = ['admin1', 'admin2'];
   const yml : any = load(readFileSync(JenkinsMainNode.BASE_JENKINS_YAML_PATH, 'utf-8'));

--- a/test/compute/jenkins-main-node.test.ts
+++ b/test/compute/jenkins-main-node.test.ts
@@ -26,9 +26,9 @@ describe('JenkinsMainNode Config Elements', () => {
 
   // THEN
   test('Config elements expected counts', async () => {
-    expect(configElements.filter((e) => e.elementType === 'COMMAND')).toHaveLength(23);
+    expect(configElements.filter((e) => e.elementType === 'COMMAND')).toHaveLength(25);
     expect(configElements.filter((e) => e.elementType === 'PACKAGE')).toHaveLength(11);
-    expect(configElements.filter((e) => e.elementType === 'FILE')).toHaveLength(4);
+    expect(configElements.filter((e) => e.elementType === 'FILE')).toHaveLength(6);
   });
 
   test('Does not use service in config elements', async () => {


### PR DESCRIPTION
### Description
This feature adds a `configHelper` python utility script to make modifying the Jenkins CASC yaml easier to understand and test locally. This script replaces previous shell functionality to add authConfig into the `jenkins.yaml` and extends support to allow nested secret structures to be placed in the authConfig secret which unblocks the current OIC auth pattern which has had a breaking change that requires this nested structure.

### Issues Resolved
https://github.com/opensearch-project/opensearch-ci/issues/515

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
