### PR TITLE
Add few fixes to minimize stack resource changes

### DIFF
--- a/lib/ci-stack.ts
+++ b/lib/ci-stack.ts
@@ -96,6 +96,7 @@ export class CIStack extends Stack {
 
     const auditloggingS3Bucket = new CiAuditLogging(this);
     const vpc = new Vpc(this, 'JenkinsVPC', {
+      availabilityZones: ['us-east-1a', 'us-east-1b', 'us-east-1c'],
       flowLogs: {
         s3: {
           destination: FlowLogDestination.toS3(auditloggingS3Bucket.bucket, 'vpcFlowLogs'),

--- a/lib/compute/jenkins-main-node.ts
+++ b/lib/compute/jenkins-main-node.ts
@@ -410,7 +410,7 @@ export class JenkinsMainNode {
       InitCommand.shellCommand('/opt/aws/amazon-cloudwatch-agent/bin/amazon-cloudwatch-agent-ctl -a fetch-config -m ec2 -c file:/opt/aws/amazon-cloudwatch-agent/etc/amazon-cloudwatch-agent.json -s'),
 
       InitCommand.shellCommand(dataRetentionProps.dataRetention
-        ? `mkdir /var/lib/jenkins && mount -t efs ${efsId} /var/lib/jenkins`
+        ? `mkdir -p /var/lib/jenkins && mount -t efs ${efsId} /var/lib/jenkins`
         : 'echo Data rentention is disabled, not mounting efs'),
 
       InitFile.fromFileInline('/docker-compose.yml', join(__dirname, '../../resources/docker-compose.yml')),


### PR DESCRIPTION
### Description
Specifying availiability zones to avoid vpc re-creation
using -p to avoid folder already /var/lib/jenkins exists error! when dataRetention parameter is set to true

### Issues Resolved
https://github.com/opensearch-project/opensearch-ci/issues/517

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
