### PR TITLE
Update windows https transport to use openssl

### DIFF
--- a/packer/scripts/windows/scoop-install-commons-docker-support.ps1
+++ b/packer/scripts/windows/scoop-install-commons-docker-support.ps1
@@ -33,6 +33,9 @@ git config --system pack.window 0
 git config --system pack.threads 1
 git config --system core.compression 0
 git config --system protocol.version 1
+git config --system http.schannelCheckRevoke false
+git config --system http.sslBackend openssl
+git config --system http.sslVerify true
 git config --system --list
 # Rename system32 find.exe in case it gets conflicted with POSIX find
 mv -v 'C:\\Windows\\System32\\find.exe' 'C:\\Windows\\System32\\find_windows.exe'


### PR DESCRIPTION
### Description
Update windows https transport to use openssl

### Issues Resolved
https://github.com/opensearch-project/opensearch-ci/issues/523

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
