### PR TITLE
Fix configHelper bug for authTpye default

### DIFF
--- a/lib/compute/jenkins-main-node.ts
+++ b/lib/compute/jenkins-main-node.ts
@@ -432,7 +432,7 @@ export class JenkinsMainNode {
       InitCommand.shellCommand(loginAuthProps.authType !== 'default'
         // eslint-disable-next-line max-len
         ? `cd /configHelper && sudo pipenv run python3 config_helper.py --initial-jenkins-config-file-path=/initial_jenkins.yaml --auth-aws-secret-arn=${loginAuthProps.authCredsSecretsArn} --auth-type=${loginAuthProps.authType} --aws-region=${stackRegion} > configHelper.log 2>&1`
-        : 'No changes made to initial_jenkins.yaml with respect to AuthType'),
+        : 'echo No changes made to initial_jenkins.yaml with respect to AuthType'),
       InitCommand.shellCommand('while [[ "$(curl -s -o /dev/null -w \'\'%{http_code}\'\' localhost:8080/api/json?pretty)" != "200" ]]; do sleep 5; done'),
 
       // Reload configuration via Jenkins.yaml


### PR DESCRIPTION
### Description
Adds missing echo keyword which is failing the resource creation when authType is set to default.
### Issues Resolved
_List any issues this PR will resolve, e.g. Closes [...]._ 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
