### PR TITLE
Update jenkins availability URL to non-auth one

### DIFF
--- a/lib/compute/jenkins-main-node.ts
+++ b/lib/compute/jenkins-main-node.ts
@@ -35,8 +35,8 @@ import { dump } from 'js-yaml';
 import { join } from 'path';
 import { CloudwatchAgent } from '../constructs/cloudwatch-agent';
 import { AgentNodeConfig, AgentNodeNetworkProps, AgentNodeProps } from './agent-node-config';
-import { EnvConfig } from './env-config';
 import { AuthConfig, FineGrainedAccessSpecs } from './auth-config';
+import { EnvConfig } from './env-config';
 import { ViewsConfig } from './views';
 
 interface HttpConfigProps {
@@ -433,7 +433,7 @@ export class JenkinsMainNode {
         // eslint-disable-next-line max-len
         ? `cd /configHelper && sudo pipenv run python3 config_helper.py --initial-jenkins-config-file-path=/initial_jenkins.yaml --auth-aws-secret-arn=${loginAuthProps.authCredsSecretsArn} --auth-type=${loginAuthProps.authType} --aws-region=${stackRegion} > configHelper.log 2>&1`
         : 'echo No changes made to initial_jenkins.yaml with respect to AuthType'),
-      InitCommand.shellCommand('while [[ "$(curl -s -o /dev/null -w \'\'%{http_code}\'\' localhost:8080/api/json?pretty)" != "200" ]]; do sleep 5; done'),
+      InitCommand.shellCommand('while [[ "$(curl -s -o /dev/null -w \'\'%{http_code}\'\' localhost:8080/login)" != "200" ]]; do sleep 5; done'),
 
       // Reload configuration via Jenkins.yaml
       InitCommand.shellCommand('cp /initial_jenkins.yaml /var/lib/jenkins/jenkins.yaml &&'


### PR DESCRIPTION
### Description

localhost:8080/api/json?pretty needs auth to be passed to check the availability. Instead using localhost:8080/login that does not require auth and correctly detects jenkins check for http status codes

### Issues Resolved
_List any issues this PR will resolve, e.g. Closes [...]._ 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
