### PR TITLE
Refactor vpc flow logs logging and monitor httpd access logs

### DIFF
--- a/lib/ci-stack.ts
+++ b/lib/ci-stack.ts
@@ -20,19 +20,19 @@ import { CiAuditLogging } from './auditing/ci-audit-logging';
 import { CIConfigStack } from './ci-config-stack';
 import { AgentNodeProps } from './compute/agent-node-config';
 import { AgentNodes } from './compute/agent-nodes';
+import { FineGrainedAccessSpecs } from './compute/auth-config';
 import { JenkinsMainNode } from './compute/jenkins-main-node';
 import { RunAdditionalCommands } from './compute/run-additional-commands';
 import { JenkinsMonitoring } from './monitoring/ci-alarms';
 import { JenkinsExternalLoadBalancer } from './network/ci-external-load-balancer';
 import { JenkinsSecurityGroups } from './security/ci-security-groups';
 import { JenkinsWAF } from './security/waf';
-import { FineGrainedAccessSpecs } from './compute/auth-config';
 
 enum DeploymentType {
-  BTR='BTR', // Build Test Release
-  GRADLE='gradle',
-  BENCHMARK='benchmark',
-  DEFAULT='default',
+  BTR = 'BTR', // Build Test Release
+  GRADLE = 'gradle',
+  BENCHMARK = 'benchmark',
+  DEFAULT = 'default',
 }
 
 export interface CIStackProps extends StackProps {

--- a/lib/ci-stack.ts
+++ b/lib/ci-stack.ts
@@ -13,6 +13,7 @@ import {
   FlowLogDestination, FlowLogTrafficType, IPeer, Peer, Vpc,
 } from 'aws-cdk-lib/aws-ec2';
 import { ListenerCertificate } from 'aws-cdk-lib/aws-elasticloadbalancingv2';
+import { LogGroup } from 'aws-cdk-lib/aws-logs';
 import { Bucket } from 'aws-cdk-lib/aws-s3';
 import { Secret } from 'aws-cdk-lib/aws-secretsmanager';
 import { Construct } from 'constructs';
@@ -97,8 +98,12 @@ export class CIStack extends Stack {
     const auditloggingS3Bucket = new CiAuditLogging(this);
     const vpc = new Vpc(this, 'JenkinsVPC', {
       flowLogs: {
-        s3: {
-          destination: FlowLogDestination.toS3(auditloggingS3Bucket.bucket, 'vpcFlowLogs'),
+        cloudwatch: {
+          destination: FlowLogDestination.toCloudWatchLogs(
+            new LogGroup(this, 'VPCFlowLogs', {
+              logGroupName: 'Jenkins/vpc/flow-logs',
+            }),
+          ),
           trafficType: FlowLogTrafficType.ALL,
         },
       },

--- a/lib/compute/jenkins-main-node.ts
+++ b/lib/compute/jenkins-main-node.ts
@@ -399,6 +399,12 @@ export class JenkinsMainNode {
                   auto_removal: false,
                   log_stream_name: 'gradle-check.log/{date}',
                 },
+                {
+                  file_path: '/var/log/httpd/access_log',
+                  log_group_name: 'JenkinsMainNode/access_log',
+                  auto_removal: false,
+                  log_stream_name: 'httpd/access_log/{date}',
+                },
               ],
             },
           },

--- a/test/ci-stack.test.ts
+++ b/test/ci-stack.test.ts
@@ -35,8 +35,8 @@ test('CI Stack Basic Resources', () => {
   template.resourceCountIs('AWS::AutoScaling::LaunchConfiguration', 1);
   template.resourceCountIs('AWS::ElasticLoadBalancingV2::LoadBalancer', 1);
   template.resourceCountIs('AWS::EC2::SecurityGroup', 4);
-  template.resourceCountIs('AWS::IAM::Policy', 1);
-  template.resourceCountIs('AWS::IAM::Role', 2);
+  template.resourceCountIs('AWS::IAM::Policy', 2);
+  template.resourceCountIs('AWS::IAM::Role', 3);
   template.resourceCountIs('AWS::S3::Bucket', 2);
   template.resourceCountIs('AWS::EC2::KeyPair', 1);
   template.resourceCountIs('AWS::IAM::InstanceProfile', 2);
@@ -437,14 +437,14 @@ test('WAF rules', () => {
         Priority: 0,
         Statement: {
           IPSetReferenceStatement:
-              {
-                Arn: {
-                  'Fn::GetAtt': [
-                    'GitHubIpv4Set',
-                    'Arn',
-                  ],
-                },
-              },
+          {
+            Arn: {
+              'Fn::GetAtt': [
+                'GitHubIpv4Set',
+                'Arn',
+              ],
+            },
+          },
         },
         VisibilityConfig: {
           CloudWatchMetricsEnabled: true,
@@ -457,14 +457,14 @@ test('WAF rules', () => {
         Priority: 1,
         Statement: {
           IPSetReferenceStatement:
-              {
-                Arn: {
-                  'Fn::GetAtt': [
-                    'GitHubIpv6Set',
-                    'Arn',
-                  ],
-                },
-              },
+          {
+            Arn: {
+              'Fn::GetAtt': [
+                'GitHubIpv6Set',
+                'Arn',
+              ],
+            },
+          },
         },
         VisibilityConfig: {
           CloudWatchMetricsEnabled: true,


### PR DESCRIPTION
### Description
- In order to enhance the security, we want to monitor the httpd access logs as well. This change adds a new log group and stream reading the httpd access log file.
- Also switches VPCflowLogs from S3 to cloudwatch 

### Issues Resolved
closes https://github.com/opensearch-project/opensearch-ci/issues/538

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
