### PR TITLE
Changes to move ci stack deployment to github action. 

### DIFF
--- a/bin/ci-stack.ts
+++ b/bin/ci-stack.ts
@@ -7,22 +7,60 @@
  */
 
 import { App } from 'aws-cdk-lib';
+import { Peer } from 'aws-cdk-lib/aws-ec2';
 import { CiCdnStack } from '../lib/ci-cdn-stack';
 import { CIConfigStack } from '../lib/ci-config-stack';
 import { CIStack } from '../lib/ci-stack';
+import { StageDefs } from './stage-definitions';
+import { FineGrainedAccessSpecs } from '../lib/compute/auth-config';
 
 const app = new App();
 
-const defaultEnv: string = 'Dev';
+const stage = app.node.tryGetContext('stage');
 
-const ciConfigStack = new CIConfigStack(app, `OpenSearch-CI-Config-${defaultEnv}`, {});
+const pl = app.node.tryGetContext('prefixList');
+const prefixList = pl !== undefined ? pl : 'pl-60b85b09';
 
-const ciStack = new CIStack(app, `OpenSearch-CI-${defaultEnv}`, {
-  env: {
-    region: process.env.CDK_DEFAULT_REGION,
-  },
-});
+if (stage === 'undefined') {
+  throw new Error("Please provide stage parameter, if deploying locally please pass 'Dev' value");
+} else if (stage !== 'Beta' && stage !== 'Prod' && stage !== 'Dev') {
+  throw new Error('Please provide a valid stage context value, it must be one of Beta, Prod or Dev');
+}
 
-const ciCdnStack = new CiCdnStack(app, `OpenSearch-CI-Cdn-${defaultEnv}`, {});
-ciCdnStack.addDependency(ciStack);
-ciStack.addDependency(ciConfigStack);
+const ciConfigStack = new CIConfigStack(app, `OpenSearch-CI-Config-${stage}`, {});
+
+if (stage === 'Dev') {
+  const ciStack = new CIStack(app, `OpenSearch-CI-${stage}`, {
+    env: {
+      region: process.env.CDK_DEFAULT_REGION,
+    },
+  });
+  ciStack.addDependency(ciConfigStack);
+} else {
+  const benchmarkFineGrainAccess: FineGrainedAccessSpecs = {
+    users: ['reta'],
+    roleName: process.env.BENCHMARK_ROLE || 'benchmark-workflow-build-access-role', // benchmark.....role
+    pattern: '(?i)benchmark-.*',
+    templateName: 'builder-template',
+  };
+
+  const ciStack = new CIStack(app, `OpenSearch-CI-${stage}`, {
+    useSsl: true,
+    authType: 'github',
+    ignoreResourcesFailures: false,
+    adminUsers: ['getsaurabh02', 'gaiksaya', 'peterzhuamazon', 'rishabh6788', 'zelinh', 'prudhvigodithi', 'Divyaasm'],
+    dataRetention: true,
+    agentAssumeRole: StageDefs[stage].agentAssumeRole,
+    macAgent: true,
+    restrictServerAccessTo: stage === 'Prod' ? Peer.anyIpv4() : Peer.prefixList(prefixList.toString()),
+    useProdAgents: true,
+    enableViews: true,
+    fineGrainedAccessSpecs: [benchmarkFineGrainAccess],
+    envVarsFilePath: './resources/envVars.yaml',
+    env: {
+      account: StageDefs[stage].accountId,
+      region: StageDefs[stage].region,
+    },
+  });
+  ciStack.addDependency(ciConfigStack);
+}

--- a/bin/stage-definitions.ts
+++ b/bin/stage-definitions.ts
@@ -1,0 +1,36 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+export interface StageDefinition {
+  readonly region: string;
+  readonly accountId: string;
+  readonly agentAssumeRole: string[];
+}
+
+export type StageMap = {
+  [key: string]: StageDefinition;
+};
+
+export const StageDefs: StageMap = {
+  Dev: {
+    region: process.env.REGION || 'us-east-1',
+    accountId: process.env.DEV_ACCOUNT_ID || '',
+    agentAssumeRole: process.env.DEV_ASSUMED_ROLES ? process.env.DEV_ASSUMED_ROLES.split(',') : [''],
+  },
+  Beta: {
+    region: process.env.REGION || 'us-east-1',
+    accountId: process.env.BETA_ACCOUNT_ID || '',
+    agentAssumeRole: process.env.ASSUMED_ROLES ? process.env.ASSUMED_ROLES.split(',') : [''],
+  },
+  Prod: {
+    region: process.env.PROD_REGION || 'us-east-1',
+    accountId: process.env.PROD_ACCOUNT_ID || '',
+    agentAssumeRole: process.env.ASSUMED_ROLES ? process.env.ASSUMED_ROLES.split(',') : [''],
+  },
+};

--- a/lib/compute/jenkins-main-node.ts
+++ b/lib/compute/jenkins-main-node.ts
@@ -416,7 +416,7 @@ export class JenkinsMainNode {
       InitCommand.shellCommand('/opt/aws/amazon-cloudwatch-agent/bin/amazon-cloudwatch-agent-ctl -a fetch-config -m ec2 -c file:/opt/aws/amazon-cloudwatch-agent/etc/amazon-cloudwatch-agent.json -s'),
 
       InitCommand.shellCommand(dataRetentionProps.dataRetention
-        ? `mkdir /var/lib/jenkins && mount -t efs ${efsId} /var/lib/jenkins`
+        ? `mkdir -p /var/lib/jenkins && mount -t efs ${efsId} /var/lib/jenkins`
         : 'echo Data rentention is disabled, not mounting efs'),
 
       InitFile.fromFileInline('/docker-compose.yml', join(__dirname, '../../resources/docker-compose.yml')),

--- a/resources/envVars.yaml
+++ b/resources/envVars.yaml
@@ -1,0 +1,7 @@
+GITHUB_BOT_TOKEN_NAME: jenkins-github-bot-token
+PUBLIC_ARTIFACT_URL: https://ci.opensearch.org/ci/dbc
+SONATYPE_STAGING_PROFILE_ID: 78d7607cc6e881
+STAGING_PROFILE_ID: 78d7607cc6e881
+REPO_URL: https://aws.oss.sonatype.org/
+PERF_TEST_CONFIG_LOCATION: bundles/tests/perf-test-config
+BENCHMARK_TEST_CONFIG_LOCATION: bundles/tests/benchmark-test-config


### PR DESCRIPTION
### Description
This is just a consolidated PR over @Divyaasm work to move jenkins ci stack deployment to opensource model. 
I have a made a few changes, such as:
* Make `stage` context var mandatory for user to specify which stack to deploy. will make it easy to specify in github actions workflow. 
* Added a hack to not delete certain exports that are used by amazon internal monitoring system, will be removed when we move to slack notification or any other opensource system. 

### Issues Resolved
_List any issues this PR will resolve, e.g. Closes [...]._ 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
