### PR TITLE
Update runners to update with jdk 24 now

### DIFF
--- a/lib/compute/agent-node-config.ts
+++ b/lib/compute/agent-node-config.ts
@@ -252,6 +252,10 @@ export class AgentNodeConfig {
                 key: 'JAVA23_HOME',
                 value: '/usr/lib/jvm/temurin-23-jdk-amd64',
               },
+              {
+                key: 'JAVA24_HOME',
+                value: '/usr/lib/jvm/temurin-24-jdk-amd64',
+              },
             ],
           },
         },

--- a/packer/scripts/macos/macos-agentsetup.sh
+++ b/packer/scripts/macos/macos-agentsetup.sh
@@ -12,7 +12,8 @@ jdk_versions=(
     "19@https://github.com/adoptium/temurin19-binaries/releases/download/jdk-19.0.2%2B7/OpenJDK19U-jdk_x64_mac_hotspot_19.0.2_7.tar.gz@1"
     "20@https://github.com/adoptium/temurin20-binaries/releases/download/jdk-20.0.2%2B9/OpenJDK20U-jdk_x64_mac_hotspot_20.0.2_9.tar.gz@1"
     "21@https://github.com/adoptium/temurin21-binaries/releases/download/jdk-21.0.1%2B12/OpenJDK21U-jdk_x64_mac_hotspot_21.0.1_12.tar.gz@1"
-    "23@https://github.com/adoptium/temurin23-binaries/releases/download/jdk-23%2B37/OpenJDK23U-jdk_x64_mac_hotspot_23_37.tar.gz@100"
+    "23@https://github.com/adoptium/temurin23-binaries/releases/download/jdk-23%2B37/OpenJDK23U-jdk_x64_mac_hotspot_23_37.tar.gz@1"
+    "24@https://github.com/adoptium/temurin24-binaries/releases/download/jdk-24.0.1%2B9/OpenJDK24U-jdk_x64_mac_hotspot_24.0.1_9.tar.gz@100"
 )
 
 ## Setup brew Defaults
@@ -33,7 +34,8 @@ if [ "$ARCH" = "arm64" ]; then
         "19@https://github.com/adoptium/temurin19-binaries/releases/download/jdk-19.0.2%2B7/OpenJDK19U-jdk_aarch64_mac_hotspot_19.0.2_7.tar.gz@1"
         "20@https://github.com/adoptium/temurin20-binaries/releases/download/jdk-20.0.2%2B9/OpenJDK20U-jdk_aarch64_mac_hotspot_20.0.2_9.tar.gz@1"
         "21@https://github.com/adoptium/temurin21-binaries/releases/download/jdk-21.0.3%2B9/OpenJDK21U-jdk_aarch64_mac_hotspot_21.0.3_9.tar.gz@1"
-        "23@https://github.com/adoptium/temurin23-binaries/releases/download/jdk-23%2B37/OpenJDK23U-jdk_aarch64_mac_hotspot_23_37.tar.gz@100"
+        "23@https://github.com/adoptium/temurin23-binaries/releases/download/jdk-23%2B37/OpenJDK23U-jdk_aarch64_mac_hotspot_23_37.tar.gz@1"
+        "24@https://github.com/adoptium/temurin24-binaries/releases/download/jdk-24.0.1%2B9/OpenJDK24U-jdk_aarch64_mac_hotspot_24.0.1_9.tar.gz@100"
     )
 fi
 $BREW_PATH/brew update --preinstall

--- a/packer/scripts/ubuntu/ubuntu2404-agent-setups.sh
+++ b/packer/scripts/ubuntu/ubuntu2404-agent-setups.sh
@@ -35,7 +35,7 @@ curl -o- https://packages.adoptium.net/artifactory/api/gpg/key/public | sudo tee
 echo "deb [signed-by=/etc/apt/keyrings/adoptium.asc] https://packages.adoptium.net/artifactory/deb $(awk -F= '/^VERSION_CODENAME/{print$2}' /etc/os-release) main" | sudo tee /etc/apt/sources.list.d/adoptium.list
 
 sudo apt-get update -y
-sudo apt-get install -y temurin-8-jdk temurin-11-jdk temurin-17-jdk temurin-21-jdk temurin-23-jdk
+sudo apt-get install -y temurin-8-jdk temurin-11-jdk temurin-17-jdk temurin-21-jdk temurin-23-jdk temurin-24-jdk
 # JDK14 required for gradle check to do bwc tests
 curl -SL "https://ci.opensearch.org/ci/dbc/tools/jdk/OpenJDK14U-jdk_x64_linux_hotspot_14.0.2_12.tar.gz" -o jdk14.tar.gz
 tar -xzf jdk14.tar.gz && rm -v jdk14.tar.gz
@@ -64,5 +64,5 @@ sudo ln -s `which awsv2` /usr/local/bin/aws
 sudo aws --install
 aws --install
 
-sudo apt-mark hold docker.io openssh-server gh grub-efi* shim-signed temurin-8-jdk temurin-11-jdk temurin-17-jdk temurin-21-jdk temurin-23-jdk
+sudo apt-mark hold docker.io openssh-server gh grub-efi* shim-signed temurin-8-jdk temurin-11-jdk temurin-17-jdk temurin-21-jdk temurin-23-jdk temurin-24-jdk
 sudo apt-get clean -y && sudo apt-get autoremove -y

--- a/resources/baseJenkins.yaml
+++ b/resources/baseJenkins.yaml
@@ -205,6 +205,12 @@ tool:
           installers:
           - adoptOpenJdkInstaller:
               id: "jdk-23.0.2+7"
+    - name: "openjdk-24"
+      properties:
+      - installSource:
+          installers:
+          - adoptOpenJdkInstaller:
+              id: "jdk-24.0.1+9"
   mavenGlobalConfig:
     globalSettingsProvider: "standard"
     settingsProvider: "standard"


### PR DESCRIPTION
### Description
Update runners to update with jdk 24 now

### Issues Resolved
https://github.com/opensearch-project/opensearch-build/pull/5426

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
