### PR TITLE
Upgrade Jenkins to 2.492.3 version

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -29,4 +29,4 @@ jobs:
           platforms: linux/amd64,linux/arm64
           context: "{{defaultContext}}:docker"
           push: true
-          tags: opensearchstaging/jenkins:2.426.3-lts-jdk21,opensearchstaging/jenkins:latest
+          tags: opensearchstaging/jenkins:2.492.3-lts-jdk21,opensearchstaging/jenkins:latest

--- a/bin/stage-definitions.ts
+++ b/bin/stage-definitions.ts
@@ -21,16 +21,16 @@ export const StageDefs: StageMap = {
   Dev: {
     region: process.env.REGION || 'us-east-1',
     accountId: process.env.DEV_ACCOUNT_ID || '',
-    agentAssumeRole: process.env.DEV_ASSUMED_ROLES ? process.env.DEV_ASSUMED_ROLES.split(',') : [''],
+    agentAssumeRole: process.env.DEV_ASSUMED_ROLES ? process.env.DEV_ASSUMED_ROLES.split(',') : [],
   },
   Beta: {
     region: process.env.REGION || 'us-east-1',
     accountId: process.env.BETA_ACCOUNT_ID || '',
-    agentAssumeRole: process.env.ASSUMED_ROLES ? process.env.ASSUMED_ROLES.split(',') : [''],
+    agentAssumeRole: process.env.ASSUMED_ROLES ? process.env.ASSUMED_ROLES.split(',') : [],
   },
   Prod: {
     region: process.env.PROD_REGION || 'us-east-1',
     accountId: process.env.PROD_ACCOUNT_ID || '',
-    agentAssumeRole: process.env.ASSUMED_ROLES ? process.env.ASSUMED_ROLES.split(',') : [''],
+    agentAssumeRole: process.env.ASSUMED_ROLES ? process.env.ASSUMED_ROLES.split(',') : [],
   },
 };

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM jenkins/jenkins:2.426.3-lts-jdk21
+FROM jenkins/jenkins:2.492.3-lts-jdk21
 LABEL maintainer="OpenSearch"
 ENV JAVA_OPTS -Djenkins.install.runSetupWizard=false
 COPY plugins.txt plugins.txt

--- a/docker/plugins.txt
+++ b/docker/plugins.txt
@@ -1,4 +1,4 @@
-durable-task:547.vd1ea_007d100c
+durable-task
 ace-editor
 adoptopenjdk
 ansicolor

--- a/lib/compute/agent-node-config.ts
+++ b/lib/compute/agent-node-config.ts
@@ -121,7 +121,7 @@ export class AgentNodeConfig {
     );
 
     /* eslint-disable eqeqeq */
-    if (assumeRole) {
+    if (assumeRole && assumeRole.length > 0) {
       // policy to allow assume role AssumeRole
       AgentNodeRole.addToPolicy(
         new PolicyStatement({

--- a/resources/baseJenkins.yaml
+++ b/resources/baseJenkins.yaml
@@ -5,9 +5,6 @@ jenkins:
       - level: "FINE"
         name: "org.jenkinsci.plugins.workflow.job.WorkflowRun"
       name: "workflowRun"
-  agentProtocols:
-  - "JNLP4-connect"
-  - "Ping"
   authorizationStrategy: "loggedInUsersCanDoAnything"
   crumbIssuer:
     standard:

--- a/resources/docker-compose.yml
+++ b/resources/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '3.8'
 services:
   jenkins:
-    image: opensearchstaging/jenkins:2.426.3-lts-jdk21
+    image: opensearchstaging/jenkins:2.492.3-lts-jdk21
     restart: on-failure
     privileged: true
     tty: true


### PR DESCRIPTION
### Description
This PR adds necessary changes to upgrade Jenkins server to version 2.492.3-LTS along with some minor bug-fixes. 
`agentProtocol` jcasc config is no longer supported. 
In my local testing windows and other agents were coming up fine and test job completed successfully while using a windows container inside a windows agent. It seems the issue with `durable-task` plugin has been fixed. 

### Issues Resolved
_List any issues this PR will resolve, e.g. Closes [...]._ 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
