### PR TITLE
Update al2 scripts to support AMI in 2025

### DIFF
--- a/packer/scripts/al2/al2-agent-setups.sh
+++ b/packer/scripts/al2/al2-agent-setups.sh
@@ -20,7 +20,8 @@ sudo yum repolist
 sudo yum update --skip-broken --exclude=openssh* --exclude=docker* -y
 
 sudo yum install -y which curl git gnupg2 tar net-tools procps-ng python3 python3-devel python3-pip zip unzip jq pigz
-sudo yum install -y docker ntp
+sudo yum install -y ntp
+sudo amazon-linux-extras install docker -y
 sudo yum groupinstall -y "Development Tools"
 
 # Install jdk21
@@ -28,7 +29,7 @@ sudo rpm --import https://yum.corretto.aws/corretto.key
 sudo curl -L -o /etc/yum.repos.d/corretto.repo https://yum.corretto.aws/corretto.repo
 sudo yum install -y java-21-amazon-corretto-devel; java -version
 
-curl -o- https://bootstrap.pypa.io/get-pip.py | python3
+curl -o- https://bootstrap.pypa.io/pip/3.7/get-pip.py | python3
 echo "export PATH=$PATH:$HOME/.local/bin" >> $HOME/.bashrc
 export PATH=$PATH:$HOME/.local/bin
 # https://github.com/opensearch-project/opensearch-build/issues/4946
@@ -36,7 +37,8 @@ pip install requests==2.28.1
 pip install docker==6.1.3
 pip install docker-compose==1.29.2
 # Temp Solution: https://github.com/opensearch-project/opensearch-build/issues/4929
-pip install --force-reinstall packaging==24.1
+# We are using Python version 3.7, Ignored the following versions that require a different python version: 24.1 Requires-Python >=3.8; 24.2 Requires-Python >=3.8; 25.0 Requires-Python >=3.8
+# pip install --force-reinstall packaging==24.1
 pip install pipenv awscli
 pipenv --version && aws --version && docker-compose --version
 
@@ -46,14 +48,9 @@ sudo systemctl restart docker && sudo systemctl enable docker && sudo systemctl 
 sudo systemctl restart ntpd && sudo systemctl enable ntpd && sudo systemctl status ntpd
 sudo usermod -a -G docker $CURR_USER
 
+sudo yum install yum-utils -y
 sudo yum-config-manager --add-repo https://cli.github.com/packages/rpm/gh-cli.repo
 sudo yum install -y gh
-
-curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.3/install.sh | bash
-. ~/.nvm/nvm.sh && nvm install 16
-
-# Node and node-packages are required globally to execute aws cdk command to setup opensearch-cluster.
-npm install -g fs-extra chalk@4.1.2 @aws-cdk/cloudformation-diff aws-cdk cdk-assume-role-credential-plugin@1.4.0
 
 sudo yum clean all
 


### PR DESCRIPTION
### Description
Update al2 scripts to support AMI in 2025

### Issues Resolved
`amazon-ebs.Jenkins-Agent-AL2-X64-2025-05-30T07-28-10Z: ERROR: This script does not work on Python 3.7. The minimum supported Python version is 3.9. Please use https://bootstrap.pypa.io/pip/3.7/get-pip.py instead.`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
