### PR TITLE
Allow for agent node configuration to be manually supplied

### DIFF
--- a/lib/ci-stack.ts
+++ b/lib/ci-stack.ts
@@ -65,6 +65,8 @@ export interface CIStackProps extends StackProps {
   readonly jenkinsInstanceType?: string | DeploymentType;
   /** Fine grain access control specifications */
   readonly fineGrainedAccessSpecs?: FineGrainedAccessSpecs[];
+  /** Alternative agent node configurations */
+  readonly alternativeNodeConfig?: AgentNodeProps[];
 }
 
 function getServerAccess(serverAccessType: string, restrictServerAccessTo: string): IPeer {
@@ -181,7 +183,7 @@ export class CIStack extends Stack {
         + 'If you do not copy the AMI in required region and update the code then the jenkins agents will not spin up.');
     }
 
-    this.agentNodes = agentNode.getRequiredAgentNodes(jenkinsInstanceType.toString());
+    this.agentNodes = props.alternativeNodeConfig ?? agentNode.getRequiredAgentNodes(jenkinsInstanceType.toString());
 
     const mainJenkinsNode = new JenkinsMainNode(this, {
       vpc,

--- a/test/compute/agent-node-config.test.ts
+++ b/test/compute/agent-node-config.test.ts
@@ -20,6 +20,7 @@ test('Agents Resource is present', () => {
   });
   const stack = new CIStack(app, 'TestStack', {
     env: { account: 'test-account', region: 'us-east-1' },
+    alternativeNodeConfig: [],
   });
   const template = Template.fromStack(stack);
 


### PR DESCRIPTION
### Description
Add flexibility for other users of this stack to specific their own agent configuration.

### Issues Resolved
- Resolves https://github.com/opensearch-project/opensearch-ci/issues/405

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
