### PR TITLE
Add onepassword service account token secret

### DIFF
--- a/lib/secrets/secret-credentials.ts
+++ b/lib/secrets/secret-credentials.ts
@@ -8,6 +8,8 @@ export class AWSSecretsJenkinsCredentials {
 
     static centralPortalMavenPassword: Secret;
 
+    static onePasswordServiceToken: Secret;
+
     static snapshotsMavenUsername: ISecret;
 
     static snapshotsMavenPassword: ISecret;
@@ -28,6 +30,12 @@ export class AWSSecretsJenkinsCredentials {
         description: 'Password for publishing snapshots to maven central portal',
       });
       Tags.of(AWSSecretsJenkinsCredentials.centralPortalMavenPassword).add('jenkins:credentials:type', 'string');
+
+      AWSSecretsJenkinsCredentials.onePasswordServiceToken = new Secret(stack, 'one-password-service-token', {
+        secretName: 'one-password-service-token',
+        description: 'Service Account Token for OnePassword to access the vaults',
+      });
+      Tags.of(AWSSecretsJenkinsCredentials.onePasswordServiceToken).add('jenkins:credentials:type', 'string');
 
       const reposWithMavenSnapshotsCredsAccess = [
         'opensearch-sdk-java',

--- a/test/ci-stack.test.ts
+++ b/test/ci-stack.test.ts
@@ -45,7 +45,7 @@ test('CI Stack Basic Resources', () => {
   template.resourceCountIs('AWS::SSM::Association', 1);
   template.resourceCountIs('AWS::EFS::FileSystem', 1);
   template.resourceCountIs('AWS::CloudWatch::Alarm', 4);
-  template.resourceCountIs('AWS::SecretsManager::Secret', 3);
+  template.resourceCountIs('AWS::SecretsManager::Secret', 4);
 
   template.hasResourceProperties('AWS::IAM::Role', {
     AssumeRolePolicyDocument: {


### PR DESCRIPTION
### Description
Add onepassword service account token secret

### Issues Resolved
https://github.com/opensearch-project/opensearch-build/issues/5535

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
