### PR TITLE
Refactor stack deployment workflow and minor fixes

### DIFF
--- a/.github/workflows/deploy-stacks.yml
+++ b/.github/workflows/deploy-stacks.yml
@@ -49,21 +49,25 @@ jobs:
             );
             const maintainers = collaborators.filter(c => c.permissions.maintain).map(c => c.login);
             return maintainers;
-
-      - name: Configure beta deployment credentials
-        uses: aws-actions/configure-aws-credentials@v4
-        with:
-          role-to-assume: ${{ secrets.BETA_DEPLOYMENT_ROLE }}
-          aws-region: 'us-east-1'
-
       - name: Create beta change-set for approval
         id: beta_stack_diff
         run: |
-          DIFF_OUTPUT=$(cdk diff -c stage=Beta | sed -E 's/[0-9]{12}/[MASKED]/g')
-          echo "diff_output<<EOF" >> $GITHUB_OUTPUT
-          echo "## CI Stacks Changeset" >> $GITHUB_OUTPUT
-          echo "$DIFF_OUTPUT" >> $GITHUB_OUTPUT
-          echo "EOF" >> $GITHUB_OUTPUT
+          cdk diff -c stage=Beta | sed -E 's/[0-9]{12}/[MASKED]/g' > beta_diff.txt
+
+          DIFF_SIZE=$(wc -c < beta_diff.txt)
+          if [ $DIFF_SIZE -gt 40000 ]; then
+            echo "diff_summary=Large changeset detected (${DIFF_SIZE} bytes). Full diff available in workflow artifacts." >> $GITHUB_OUTPUT
+          else
+            echo "diff_summary<<EOF" >> $GITHUB_OUTPUT
+            cat beta_diff.txt >> $GITHUB_OUTPUT
+            echo "EOF" >> $GITHUB_OUTPUT
+          fi
+      - name: Upload beta diff as artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: beta-stack-diff
+          path: beta_diff.txt
+          retention-days: 30
       - name: Approve or Deny beta change set
         uses: trstringer/manual-approval@v1
         with:
@@ -72,30 +76,49 @@ jobs:
           minimum-approvals: 1
           issue-title: 'Request to approve/deny Beta CI Stack Deployment'
           issue-body: |
+            ## Beta Stack Deployment Request
+
+            **Workflow Run:** ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+
             <details>
             <summary>Beta Stack Changeset Details</summary>
 
             ```
-            ${{ steps.beta_stack_diff.outputs.diff_output }}
+            ${{ steps.beta_stack_diff.outputs.diff_summary }}
             ```
+
+            📎 **Full diff available in workflow artifacts:** [beta-stack-diff](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }})
+
             </details>
+      - name: Configure beta deployment credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.BETA_DEPLOYMENT_ROLE }}
+          aws-region: 'us-east-1'
       - name: Deploy beta stacks
         run: |
           cdk deploy "*" -c stage=Beta --require-approval=never
-
-      - name: Configure Production deployment credentials
-        uses: aws-actions/configure-aws-credentials@v4
-        with:
-          role-to-assume: ${{ secrets.PROD_DEPLOYMENT_ROLE }}
-          aws-region: 'us-east-1'
       - name: Create Production change-set for approval
         id: prod_stack_diff
         run: |
-          DIFF_OUTPUT=$(cdk diff -c stage=Prod | sed -E 's/[0-9]{12}/[MASKED]/g')
-          echo "diff_output<<EOF" >> $GITHUB_OUTPUT
-          echo "## CI Stacks Changeset" >> $GITHUB_OUTPUT
-          echo "$DIFF_OUTPUT" >> $GITHUB_OUTPUT
-          echo "EOF" >> $GITHUB_OUTPUT
+          # Generate diff and save to file
+          cdk diff -c stage=Prod | sed -E 's/[0-9]{12}/[MASKED]/g' > prod_diff.txt
+
+          # Create summary for issue body
+          DIFF_SIZE=$(wc -c < prod_diff.txt)
+          if [ $DIFF_SIZE -gt 40000 ]; then
+            echo "diff_summary=Large changeset detected (${DIFF_SIZE} bytes). Full diff available in workflow artifacts." >> $GITHUB_OUTPUT
+          else
+            echo "diff_summary<<EOF" >> $GITHUB_OUTPUT
+            cat prod_diff.txt >> $GITHUB_OUTPUT
+            echo "EOF" >> $GITHUB_OUTPUT
+          fi
+      - name: Upload production diff as artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: production-stack-diff
+          path: prod_diff.txt
+          retention-days: 30
       - name: Approve or Deny Production change set
         uses: trstringer/manual-approval@v1
         with:
@@ -104,13 +127,25 @@ jobs:
           minimum-approvals: 1
           issue-title: 'Request to approve/deny Production CI Stack Deployment'
           issue-body: |
+            ## Production Stack Deployment Request
+
+            **Workflow Run:** ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+
             <details>
             <summary>Production Stack Changeset Details</summary>
 
             ```
-            ${{ steps.prod_stack_diff.outputs.diff_output }}
+            ${{ steps.prod_stack_diff.outputs.diff_summary }}
             ```
+
+            📎 **Full diff available in workflow artifacts:** [production-stack-diff](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }})
+
             </details>
+      - name: Configure Production deployment credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.PROD_DEPLOYMENT_ROLE }}
+          aws-region: 'us-east-1'
       - name: Deploy Production stacks
         run: |
           cdk deploy "*" -c stage=Prod --require-approval=never

--- a/lib/secrets/gha-federate-access.ts
+++ b/lib/secrets/gha-federate-access.ts
@@ -1,10 +1,11 @@
 import { Stack } from 'aws-cdk-lib';
 import {
-  OpenIdConnectPrincipal, OpenIdConnectProvider, PolicyStatement, Role,
+  IOpenIdConnectProvider,
+  OpenIdConnectPrincipal, PolicyStatement, Role,
 } from 'aws-cdk-lib/aws-iam';
 
 export class GitHubActionsFederateIntegrationForTags {
-  constructor(stack: Stack, provider: OpenIdConnectProvider, secretArns: string[], githubRepo: string) {
+  constructor(stack: Stack, provider: IOpenIdConnectProvider, secretArns: string[], githubRepo: string) {
     // creating IAM role for accessing secret only using tags
     const ghaRole = new Role(stack, `${githubRepo}-github-role`, {
       roleName: `${githubRepo}-secret-access-role-for-tags`,
@@ -26,7 +27,7 @@ export class GitHubActionsFederateIntegrationForTags {
 }
 
 export class GitHubActionsFederateIntegrationForBranchesAndTags {
-  constructor(stack: Stack, provider: OpenIdConnectProvider, secretArns: string[], githubRepo: string) {
+  constructor(stack: Stack, provider: IOpenIdConnectProvider, secretArns: string[], githubRepo: string) {
     // creating IAM role for accessing secret only using branches
     // Ensure roleName meets AWS IAM requirements: alphanumeric characters and _+=,.@- only, max 64 chars
     const sanitizedRepo = githubRepo.replace(/[^a-zA-Z0-9_+=,.@-]/g, '-');
@@ -54,7 +55,7 @@ export class GitHubActionsFederateIntegrationForBranchesAndTags {
 }
 
 export class GitHubActionsFederateIntegrationForBranchesOnGenericActionsAndResources {
-  constructor(stack: Stack, provider: OpenIdConnectProvider, Actions: string[], Resources: string[], roleNamePostfix: string, githubRepo: string) {
+  constructor(stack: Stack, provider: IOpenIdConnectProvider, Actions: string[], Resources: string[], roleNamePostfix: string, githubRepo: string) {
     // creating IAM role for accessing secret only using branches on generic actions and resources`
     const ghaBranchRoleGeneric = new Role(stack, `${githubRepo}-github-role-branches-generic-actions-resources-${roleNamePostfix}`, {
       roleName: `${githubRepo}-role-branches-generic-${roleNamePostfix}`,

--- a/lib/secrets/secret-credentials.ts
+++ b/lib/secrets/secret-credentials.ts
@@ -74,15 +74,8 @@ export class AWSSecretsJenkinsCredentials {
         'opensearch-protobufs',
       ];
 
-      // creating Github OIDC
-      const provider = new OpenIdConnectProvider(stack, 'github-open-id-connect', {
-        url: 'https://token.actions.githubusercontent.com',
-        clientIds: ['sts.amazonaws.com'],
-        thumbprints: [
-          '1C58A3A8518E8759BF075B76B750D4F2DF264FCD',
-          'F879ABCE0008E4EB126E0097E46620F5AAAE26AD',
-        ],
-      });
+      const provider = OpenIdConnectProvider.fromOpenIdConnectProviderArn(stack, 'open-id-connect-provider',
+        `arn:aws:iam::${stack.account}:oidc-provider/token.actions.githubusercontent.com`);
 
       reposWithMavenSnapshotsCredsAccess.forEach((repo) => {
         new GitHubActionsFederateIntegrationForBranchesAndTags(stack, provider,

--- a/test/ci-stack.test.ts
+++ b/test/ci-stack.test.ts
@@ -9,6 +9,7 @@
 import { App } from 'aws-cdk-lib';
 import { Match, Template } from 'aws-cdk-lib/assertions';
 import { Peer } from 'aws-cdk-lib/aws-ec2';
+import { Effect } from 'aws-cdk-lib/aws-iam';
 import { CIStack } from '../lib/ci-stack';
 import { AgentNodes } from '../lib/compute/agent-nodes';
 
@@ -37,7 +38,7 @@ test('CI Stack Basic Resources', () => {
   template.resourceCountIs('AWS::ElasticLoadBalancingV2::LoadBalancer', 1);
   template.resourceCountIs('AWS::EC2::SecurityGroup', 4);
   template.resourceCountIs('AWS::IAM::Policy', 36);
-  template.resourceCountIs('AWS::IAM::Role', 38);
+  template.resourceCountIs('AWS::IAM::Role', 37);
   template.resourceCountIs('AWS::S3::Bucket', 2);
   template.resourceCountIs('AWS::EC2::KeyPair', 1);
   template.resourceCountIs('AWS::IAM::InstanceProfile', 2);
@@ -52,10 +53,6 @@ test('CI Stack Basic Resources', () => {
       Statement: [
         Match.objectLike({
           Action: 'sts:AssumeRoleWithWebIdentity',
-          Effect: 'Allow',
-          Principal: {
-            Federated: { Ref: 'githubopenidconnectE4C4027C' },
-          },
           Condition: {
             StringLike: {
               'token.actions.githubusercontent.com:sub': 'repo:opensearch-project/opensearch-jvector:ref:refs/*',
@@ -64,7 +61,12 @@ test('CI Stack Basic Resources', () => {
               'token.actions.githubusercontent.com:aud': 'sts.amazonaws.com',
             },
           },
+          Effect: 'Allow',
+          Principal: {
+            Federated: 'arn:aws:iam::test-account:oidc-provider/token.actions.githubusercontent.com',
+          },
         }),
+
       ],
       Version: '2012-10-17',
     },


### PR DESCRIPTION
### Description
The ci stack deployment failed at step to create an issue for manual approval due to large size of `cdk diff` output being written to `GITHUB_ENV`, the diff size was 177kB while max size of GITHUB_ENV variable is 48kB. 
Refactored the workflow check the size of cdk diff output and if it is greater than 40kB, then attach the full output to the workflow instead of writing it as issue content. 

This PR also adds a change to import the existing OIDC provider custom resource deployed using internal stack and use that to refer in the roles. 

### Issues Resolved
_List any issues this PR will resolve, e.g. Closes [...]._ 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
