### PR TITLE
fix secret arn import method

### DIFF
--- a/lib/secrets/secret-credentials.ts
+++ b/lib/secrets/secret-credentials.ts
@@ -15,9 +15,11 @@ export class AWSSecretsJenkinsCredentials {
     static snapshotsMavenPassword: ISecret;
 
     constructor(stack: Stack) {
-      AWSSecretsJenkinsCredentials.snapshotsMavenPassword = Secret.fromSecretNameV2(stack, 'imported-maven-snapshots-password', 'maven-snapshots-password');
+      AWSSecretsJenkinsCredentials.snapshotsMavenPassword = Secret.fromSecretCompleteArn(stack, 'imported-maven-snapshots-password',
+        `arn:aws:secretsmanager:us-east-1:${stack.account}:secret:maven-snapshots-password-uMmbAR`);
 
-      AWSSecretsJenkinsCredentials.snapshotsMavenUsername = Secret.fromSecretNameV2(stack, 'imported-maven-snapshots-username', 'maven-snapshots-username');
+      AWSSecretsJenkinsCredentials.snapshotsMavenUsername = Secret.fromSecretCompleteArn(stack, 'imported-maven-snapshots-username',
+        `arn:aws:secretsmanager:us-east-1:${stack.account}:secret:maven-snapshots-username-xfOoXz`);
 
       AWSSecretsJenkinsCredentials.centralPortalMavenUsername = new Secret(stack, 'maven-central-portal-username', {
         secretName: 'maven-central-portal-username',

--- a/test/ci-stack.test.ts
+++ b/test/ci-stack.test.ts
@@ -82,7 +82,7 @@ test('External security group is open', () => {
   });
 
   // WHEN
-  const stack = new CIStack(app, 'MyTestStack', { env: { account: 'test-account', region: 'us-east-1' } });
+  const stack = new CIStack(app, 'MyTestStack', { env: { account: 'test-account', region: 'us-east-1' }, useProdAgents: false });
   const template = Template.fromStack(stack);
 
   // THEN


### PR DESCRIPTION
### Description
Use `Secret.fromSecretCompleteArn` method instead of `Secret.fromSecretNameV2` to import full secret arn, the latter imports only partial due to truncate logic. 

### Issues Resolved
_List any issues this PR will resolve, e.g. Closes [...]._ 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
