### PR TITLE
Ensure User set to root when installing op cli

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -2,5 +2,7 @@ FROM jenkins/jenkins:2.492.3-lts-jdk21
 LABEL maintainer="OpenSearch"
 ENV JAVA_OPTS -Djenkins.install.runSetupWizard=false
 COPY plugins.txt plugins.txt
+USER 0
 RUN curl -SfL https://raw.githubusercontent.com/opensearch-project/opensearch-build/refs/heads/main/docker/ci/config/op-setup.sh -o op-setup.sh && bash op-setup.sh && rm -v op-setup.sh
+USER jenkins
 RUN jenkins-plugin-cli -f plugins.txt --verbose


### PR DESCRIPTION
### Description
Ensure User set to root when installing op cli

### Issues Resolved
https://github.com/opensearch-project/opensearch-build/issues/5535

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
