### PR TITLE
Support adding GitHub teams to fine grained access & give bot build access

### DIFF
--- a/test/compute/auth-config.test.ts
+++ b/test/compute/auth-config.test.ts
@@ -47,6 +47,7 @@ describe('Test authType github', () => {
   const yml: any = load(readFileSync(JenkinsMainNode.BASE_JENKINS_YAML_PATH, 'utf-8'));
   const fineGrainedAccess: FineGrainedAccessSpecs = {
     users: ['user1', 'user2', 'user3'],
+    groups: ['some-org*team1'],
     roleName: 'builder-job-role',
     pattern: '((distribution|integ).*)',
     templateName: 'builder-template',
@@ -96,7 +97,15 @@ describe('Test authType github', () => {
     const builderRole = yml.jenkins.authorizationStrategy.roleBased.roles.items.find((role: any) => role.name === 'builder-job-role');
 
     // Check users
-    const buildUsers = builderRole.entries.map((entry: any) => entry.user);
+    const buildUsers = builderRole.entries
+      .filter((entry: any) => entry.user)
+      .map((entry: any) => entry.user);
     expect(buildUsers).toEqual(['user1', 'user2', 'user3']);
+
+    // Check groups
+    const buildGroups = builderRole.entries
+      .filter((entry: any) => entry.group)
+      .map((entry: any) => entry.group);
+    expect(buildGroups).toEqual(['some-org*team1']);
   });
 });


### PR DESCRIPTION
### Description
This change adds support to add GitHub teams as a group access when fine grained access is enabled via OIDC. See https://plugins.jenkins.io/github-oauth/
```
organization*team - give permissions to a specific GitHub team of a GitHub organization. Notice that organization and team are separated by an asterisk (*).
```

This change also gives bot access to build [manifest-update](https://build.ci.opensearch.org/job/manifest-update/) workflow that will be triggered automatically in future as a part of below mentioned issue. 

### Issues Resolved
part of https://github.com/opensearch-project/opensearch-build/issues/4225

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
