### PR TITLE
Add data prepper account details as credentials

### DIFF
--- a/lib/secrets/secret-credentials.ts
+++ b/lib/secrets/secret-credentials.ts
@@ -53,6 +53,12 @@ export class AWSSecretsJenkinsCredentials {
     });
     Tags.of(dataPrepperAWSaccount).add('jenkins:credentials:type', 'string');
 
+    const dataPrepperS3BucketName = new Secret(stack, 'data-prepper-s3-bucket-name', {
+      secretName: 'data-prepper-s3-bucket-name',
+      description: 'Data Prepper S3 bucket name',
+    });
+    Tags.of(dataPrepperS3BucketName).add('jenkins:credentials:type', 'string');
+
     const reposWithMavenSnapshotsCredsAccess = [
       'opensearch-sdk-java',
       'opensearch-java',

--- a/lib/secrets/secret-credentials.ts
+++ b/lib/secrets/secret-credentials.ts
@@ -1,96 +1,104 @@
 import { Stack, Tags } from 'aws-cdk-lib';
-import { ISecret, Secret } from 'aws-cdk-lib/aws-secretsmanager';
 import { OpenIdConnectProvider } from 'aws-cdk-lib/aws-iam';
+import { ISecret, Secret } from 'aws-cdk-lib/aws-secretsmanager';
 import { GitHubActionsFederateIntegrationForBranchesAndTags } from './gha-federate-access';
 
 export class AWSSecretsJenkinsCredentials {
-    static centralPortalMavenUsername: Secret;
+  static centralPortalMavenUsername: Secret;
 
-    static centralPortalMavenPassword: Secret;
+  static centralPortalMavenPassword: Secret;
 
-    static onePasswordServiceToken: Secret;
+  static snapshotsMavenUsername: ISecret;
 
-    static remoteVectorIndexBuilderWebhookToken: Secret;
+  static snapshotsMavenPassword: ISecret;
 
-    static snapshotsMavenUsername: ISecret;
+  constructor(stack: Stack) {
+    AWSSecretsJenkinsCredentials.snapshotsMavenPassword = Secret.fromSecretNameV2(stack, 'imported-maven-snapshots-password', 'maven-snapshots-password');
 
-    static snapshotsMavenPassword: ISecret;
+    AWSSecretsJenkinsCredentials.snapshotsMavenUsername = Secret.fromSecretNameV2(stack, 'imported-maven-snapshots-username', 'maven-snapshots-username');
 
-    constructor(stack: Stack) {
-      AWSSecretsJenkinsCredentials.snapshotsMavenPassword = Secret.fromSecretNameV2(stack, 'imported-maven-snapshots-password', 'maven-snapshots-password');
+    AWSSecretsJenkinsCredentials.centralPortalMavenUsername = new Secret(stack, 'maven-central-portal-username', {
+      secretName: 'maven-central-portal-username',
+      description: 'Username for publishing snapshots to maven central portal',
+    });
+    Tags.of(AWSSecretsJenkinsCredentials.centralPortalMavenUsername).add('jenkins:credentials:type', 'string');
 
-      AWSSecretsJenkinsCredentials.snapshotsMavenUsername = Secret.fromSecretNameV2(stack, 'imported-maven-snapshots-username', 'maven-snapshots-username');
+    AWSSecretsJenkinsCredentials.centralPortalMavenPassword = new Secret(stack, 'maven-central-portal-password', {
+      secretName: 'maven-central-portal-password',
+      description: 'Password for publishing snapshots to maven central portal',
+    });
+    Tags.of(AWSSecretsJenkinsCredentials.centralPortalMavenPassword).add('jenkins:credentials:type', 'string');
 
-      AWSSecretsJenkinsCredentials.centralPortalMavenUsername = new Secret(stack, 'maven-central-portal-username', {
-        secretName: 'maven-central-portal-username',
-        description: 'Username for publishing snapshots to maven central portal',
-      });
-      Tags.of(AWSSecretsJenkinsCredentials.centralPortalMavenUsername).add('jenkins:credentials:type', 'string');
+    const onePasswordServiceToken = new Secret(stack, 'one-password-service-token', {
+      secretName: 'one-password-service-token',
+      description: 'Service Account Token for OnePassword to access the vaults',
+    });
+    Tags.of(onePasswordServiceToken).add('jenkins:credentials:type', 'string');
 
-      AWSSecretsJenkinsCredentials.centralPortalMavenPassword = new Secret(stack, 'maven-central-portal-password', {
-        secretName: 'maven-central-portal-password',
-        description: 'Password for publishing snapshots to maven central portal',
-      });
-      Tags.of(AWSSecretsJenkinsCredentials.centralPortalMavenPassword).add('jenkins:credentials:type', 'string');
+    const remoteVectorIndexBuilderWebhookToken = new Secret(stack, 'jenkins-remote-vector-index-builder-generic-webhook-token', {
+      secretName: 'jenkins-remote-vector-index-builder-generic-webhook-token',
+      description: 'Generic webhook token to trigger remote-vector-index-builder-release-images workflows in build.ci.opensearch.org jenkins instance',
+    });
+    Tags.of(remoteVectorIndexBuilderWebhookToken).add('jenkins:credentials:type', 'string');
 
-      AWSSecretsJenkinsCredentials.onePasswordServiceToken = new Secret(stack, 'one-password-service-token', {
-        secretName: 'one-password-service-token',
-        description: 'Service Account Token for OnePassword to access the vaults',
-      });
-      Tags.of(AWSSecretsJenkinsCredentials.onePasswordServiceToken).add('jenkins:credentials:type', 'string');
+    const dataPrepperS3Role = new Secret(stack, 'data-prepper-s3-role', {
+      secretName: 'data-prepper-s3-role',
+      description: 'Data Prepper IAM role to download artifacts',
+    });
+    Tags.of(dataPrepperS3Role).add('jenkins:credentials:type', 'string');
 
-      AWSSecretsJenkinsCredentials.remoteVectorIndexBuilderWebhookToken = new Secret(stack, 'jenkins-remote-vector-index-builder-generic-webhook-token', {
-        secretName: 'jenkins-remote-vector-index-builder-generic-webhook-token',
-        description: 'Generic webhook token to trigger remote-vector-index-builder-release-images workflows in build.ci.opensearch.org jenkins instance',
-      });
-      Tags.of(AWSSecretsJenkinsCredentials.remoteVectorIndexBuilderWebhookToken).add('jenkins:credentials:type', 'string');
+    const dataPrepperAWSaccount = new Secret(stack, 'data-prepper-aws-account-number', {
+      secretName: 'data-prepper-aws-account-number',
+      description: 'Data Prepper Account ID to download artifacts',
+    });
+    Tags.of(dataPrepperAWSaccount).add('jenkins:credentials:type', 'string');
 
-      const reposWithMavenSnapshotsCredsAccess = [
-        'opensearch-sdk-java',
-        'opensearch-java',
-        'spring-data-opensearch',
-        'security',
-        'index-management',
-        'sql',
-        'reporting',
-        'alerting',
-        'anomaly-detection',
-        'asynchronous-search',
-        'job-scheduler',
-        'k-NN',
-        'performance-analyzer',
-        'observability',
-        'notifications',
-        'cross-cluster-replication',
-        'common-utils',
-        'ml-commons',
-        'geospatial',
-        'security-analytics',
-        'neural-search',
-        'OpenSearch',
-        'flow-framework',
-        'opensearch-testcontainers',
-        'opensearch-hadoop',
-        'performance-analyzer-commons',
-        'opensearch-spark',
-        'custom-codecs',
-        'skills',
-        'query-insights',
-        'opensearch-system-templates',
-        'opensearch-remote-metadata-sdk',
-        'opensearch-jvector',
-        'opensearch-protobufs',
-      ];
+    const reposWithMavenSnapshotsCredsAccess = [
+      'opensearch-sdk-java',
+      'opensearch-java',
+      'spring-data-opensearch',
+      'security',
+      'index-management',
+      'sql',
+      'reporting',
+      'alerting',
+      'anomaly-detection',
+      'asynchronous-search',
+      'job-scheduler',
+      'k-NN',
+      'performance-analyzer',
+      'observability',
+      'notifications',
+      'cross-cluster-replication',
+      'common-utils',
+      'ml-commons',
+      'geospatial',
+      'security-analytics',
+      'neural-search',
+      'OpenSearch',
+      'flow-framework',
+      'opensearch-testcontainers',
+      'opensearch-hadoop',
+      'performance-analyzer-commons',
+      'opensearch-spark',
+      'custom-codecs',
+      'skills',
+      'query-insights',
+      'opensearch-system-templates',
+      'opensearch-remote-metadata-sdk',
+      'opensearch-jvector',
+      'opensearch-protobufs',
+    ];
 
-      const provider = OpenIdConnectProvider.fromOpenIdConnectProviderArn(stack, 'open-id-connect-provider',
-        `arn:aws:iam::${stack.account}:oidc-provider/token.actions.githubusercontent.com`);
+    const provider = OpenIdConnectProvider.fromOpenIdConnectProviderArn(stack, 'open-id-connect-provider',
+      `arn:aws:iam::${stack.account}:oidc-provider/token.actions.githubusercontent.com`);
 
-      reposWithMavenSnapshotsCredsAccess.forEach((repo) => {
-        new GitHubActionsFederateIntegrationForBranchesAndTags(stack, provider,
-          [AWSSecretsJenkinsCredentials.snapshotsMavenUsername.secretArn,
-            AWSSecretsJenkinsCredentials.snapshotsMavenPassword.secretArn,
-            AWSSecretsJenkinsCredentials.centralPortalMavenUsername.secretArn,
-            AWSSecretsJenkinsCredentials.centralPortalMavenPassword.secretArn], repo);
-      });
-    }
+    reposWithMavenSnapshotsCredsAccess.forEach((repo) => {
+      new GitHubActionsFederateIntegrationForBranchesAndTags(stack, provider,
+        [AWSSecretsJenkinsCredentials.snapshotsMavenUsername.secretArn,
+          AWSSecretsJenkinsCredentials.snapshotsMavenPassword.secretArn,
+          AWSSecretsJenkinsCredentials.centralPortalMavenUsername.secretArn,
+          AWSSecretsJenkinsCredentials.centralPortalMavenPassword.secretArn], repo);
+    });
+  }
 }

--- a/test/ci-stack.test.ts
+++ b/test/ci-stack.test.ts
@@ -45,7 +45,7 @@ test('CI Stack Basic Resources', () => {
   template.resourceCountIs('AWS::SSM::Association', 1);
   template.resourceCountIs('AWS::EFS::FileSystem', 1);
   template.resourceCountIs('AWS::CloudWatch::Alarm', 4);
-  template.resourceCountIs('AWS::SecretsManager::Secret', 7);
+  template.resourceCountIs('AWS::SecretsManager::Secret', 8);
 
   template.hasResourceProperties('AWS::IAM::Role', {
     AssumeRolePolicyDocument: {

--- a/test/ci-stack.test.ts
+++ b/test/ci-stack.test.ts
@@ -9,7 +9,6 @@
 import { App } from 'aws-cdk-lib';
 import { Match, Template } from 'aws-cdk-lib/assertions';
 import { Peer } from 'aws-cdk-lib/aws-ec2';
-import { Effect } from 'aws-cdk-lib/aws-iam';
 import { CIStack } from '../lib/ci-stack';
 import { AgentNodes } from '../lib/compute/agent-nodes';
 
@@ -46,7 +45,7 @@ test('CI Stack Basic Resources', () => {
   template.resourceCountIs('AWS::SSM::Association', 1);
   template.resourceCountIs('AWS::EFS::FileSystem', 1);
   template.resourceCountIs('AWS::CloudWatch::Alarm', 4);
-  template.resourceCountIs('AWS::SecretsManager::Secret', 5);
+  template.resourceCountIs('AWS::SecretsManager::Secret', 7);
 
   template.hasResourceProperties('AWS::IAM::Role', {
     AssumeRolePolicyDocument: {


### PR DESCRIPTION
### Description
We are planning on retrieving data prepper artifacts using s3Download for which we would need role name and account ID of the data-prepper S3 bucket where artifacts are hosted. Adding them as secrets so that it can be used in code using `withCredentials` block.
Also refactors some of the code where secrets were static which are not required. 

### Issues Resolved
part of https://github.com/opensearch-project/opensearch-build/issues/5586

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
