### PR TITLE
Update maven secrets and remove repo access

### DIFF
--- a/lib/secrets/secret-credentials.ts
+++ b/lib/secrets/secret-credentials.ts
@@ -4,10 +4,6 @@ import { ISecret, Secret } from 'aws-cdk-lib/aws-secretsmanager';
 import { GitHubActionsFederateIntegrationForBranchesAndTags } from './gha-federate-access';
 
 export class AWSSecretsJenkinsCredentials {
-  static centralPortalMavenUsername: Secret;
-
-  static centralPortalMavenPassword: Secret;
-
   static snapshotsMavenUsername: ISecret;
 
   static snapshotsMavenPassword: ISecret;
@@ -17,17 +13,17 @@ export class AWSSecretsJenkinsCredentials {
 
     AWSSecretsJenkinsCredentials.snapshotsMavenUsername = Secret.fromSecretNameV2(stack, 'imported-maven-snapshots-username', 'maven-snapshots-username');
 
-    AWSSecretsJenkinsCredentials.centralPortalMavenUsername = new Secret(stack, 'maven-central-portal-username', {
+    const centralPortalMavenUsername = new Secret(stack, 'maven-central-portal-username', {
       secretName: 'maven-central-portal-username',
-      description: 'Username for publishing snapshots to maven central portal',
+      description: 'Username for publishing artifacts to maven central portal',
     });
-    Tags.of(AWSSecretsJenkinsCredentials.centralPortalMavenUsername).add('jenkins:credentials:type', 'string');
+    Tags.of(centralPortalMavenUsername).add('jenkins:credentials:type', 'string');
 
-    AWSSecretsJenkinsCredentials.centralPortalMavenPassword = new Secret(stack, 'maven-central-portal-password', {
-      secretName: 'maven-central-portal-password',
-      description: 'Password for publishing snapshots to maven central portal',
+    const centralPortalMavenPassword = new Secret(stack, 'maven-central-portal-token', {
+      secretName: 'maven-central-portal-token',
+      description: 'Token for publishing artifacts to maven central portal',
     });
-    Tags.of(AWSSecretsJenkinsCredentials.centralPortalMavenPassword).add('jenkins:credentials:type', 'string');
+    Tags.of(centralPortalMavenPassword).add('jenkins:credentials:type', 'string');
 
     const onePasswordServiceToken = new Secret(stack, 'one-password-service-token', {
       secretName: 'one-password-service-token',
@@ -102,9 +98,7 @@ export class AWSSecretsJenkinsCredentials {
     reposWithMavenSnapshotsCredsAccess.forEach((repo) => {
       new GitHubActionsFederateIntegrationForBranchesAndTags(stack, provider,
         [AWSSecretsJenkinsCredentials.snapshotsMavenUsername.secretArn,
-          AWSSecretsJenkinsCredentials.snapshotsMavenPassword.secretArn,
-          AWSSecretsJenkinsCredentials.centralPortalMavenUsername.secretArn,
-          AWSSecretsJenkinsCredentials.centralPortalMavenPassword.secretArn], repo);
+          AWSSecretsJenkinsCredentials.snapshotsMavenPassword.secretArn], repo);
     });
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "opensearch-ci-stack",
-  "version": "1.0.0",
+  "version": "1.4.4",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "opensearch-ci-stack",
-      "version": "1.0.0",
+      "version": "1.4.4",
       "dependencies": {
         "@typescript-eslint/eslint-plugin": "^4.31.1",
         "@typescript-eslint/parser": "^4.31.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "opensearch-ci-stack",
-  "version": "1.0.0",
+  "version": "1.4.4",
   "bin": {
     "ci": "bin/ci-stack.js"
   },
@@ -19,7 +19,7 @@
     "constructs": "10.1.67",
     "jest": "^26.4.2",
     "ts-jest": "^26.2.0",
-    "micromatch":"^4.0.6",
+    "micromatch": "^4.0.6",
     "ts-node": "^9.0.0",
     "typescript": "~3.9.7"
   },


### PR DESCRIPTION
### Description

- This minor change updates the maven credentials with right name and description.
- Also removes repo access to these credentials as we are now using one password via LF instead of AWS secrets.
- We were also not bumping the package.json which should match the tag version everytime. Fixing it too.

### Issues Resolved
https://github.com/opensearch-project/opensearch-build/issues/5551 https://github.com/opensearch-project/opensearch-build/issues/5548

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
