### PR TITLE
Remove gradle check logger to fix cloudwatch agent failures

### DIFF
--- a/lib/compute/jenkins-main-node.ts
+++ b/lib/compute/jenkins-main-node.ts
@@ -396,12 +396,6 @@ export class JenkinsMainNode {
                   log_stream_name: 'workflow-logs',
                 },
                 {
-                  file_path: '/var/lib/jenkins/jobs/gradle-check/builds/*/log',
-                  log_group_name: 'JenkinsMainNode/gradle-check.log',
-                  auto_removal: false,
-                  log_stream_name: 'gradle-check.log/{date}',
-                },
-                {
                   file_path: '/var/log/httpd/access_log',
                   log_group_name: 'JenkinsMainNode/access_log',
                   auto_removal: false,

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "opensearch-ci-stack",
-  "version": "1.4.4",
+  "version": "1.4.5",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "opensearch-ci-stack",
-      "version": "1.4.4",
+      "version": "1.4.5",
       "dependencies": {
         "@typescript-eslint/eslint-plugin": "^4.31.1",
         "@typescript-eslint/parser": "^4.31.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "opensearch-ci-stack",
-  "version": "1.4.4",
+  "version": "1.4.5",
   "bin": {
     "ci": "bin/ci-stack.js"
   },


### PR DESCRIPTION
### Description
Cloudwatch agent was being killed due to below error:
```
2025-07-02T17:12:11Z I! [logagent] piping log from JenkinsMainNode/gradle-check.log/gradle-check.log/2025-07-01(/var/lib/jenkins/jobs/gradle-check/builds/59946/log) to cloudwatchlogs with retention -1
2025-07-02T17:18:55Z E! [inputs.logfile] Failed to find target files for file config /var/lib/jenkins/jobs/gradle-check/builds/*/log, with error: error tailing file /var/lib/jenkins/jobs/gradle-check/builds/55494/log with error: lstat /var/lib/jenkins/jobs/gradle-check/builds/55494
: no such file or directory
```
The log discarder is set to [90 days](https://github.com/opensearch-project/opensearch-build/blob/main/jenkins/gradle/gradle-check.jenkinsfile#L19) which causes the older files to be missing. Removing the log monitoring for the same

### Issues Resolved
_List any issues this PR will resolve, e.g. Closes [...]._ 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
