### PR TITLE
Set auto removal to false for workflow run logs

### DIFF
--- a/lib/compute/jenkins-main-node.ts
+++ b/lib/compute/jenkins-main-node.ts
@@ -392,7 +392,7 @@ export class JenkinsMainNode {
                 {
                   file_path: '/var/lib/jenkins/logs/custom/workflowRun.log',
                   log_group_name: 'JenkinsMainNode/workflow.log',
-                  auto_removal: true,
+                  auto_removal: false,
                   log_stream_name: 'workflow-logs',
                 },
                 {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "opensearch-ci-stack",
-  "version": "1.4.5",
+  "version": "1.4.6",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "opensearch-ci-stack",
-      "version": "1.4.5",
+      "version": "1.4.6",
       "dependencies": {
         "@typescript-eslint/eslint-plugin": "^4.31.1",
         "@typescript-eslint/parser": "^4.31.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "opensearch-ci-stack",
-  "version": "1.4.5",
+  "version": "1.4.6",
   "bin": {
     "ci": "bin/ci-stack.js"
   },


### PR DESCRIPTION
### Description
Set auto removal to false for workflow run logs as cloudwatch agent is deleting the file after reading causing the logger to stop writing. 

### Issues Resolved
_List any issues this PR will resolve, e.g. Closes [...]._ 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
