### PR TITLE
Add OSCAR chatbot related build access role through opensearch-ci-bot

### DIFF
--- a/bin/ci-stack.ts
+++ b/bin/ci-stack.ts
@@ -46,14 +46,7 @@ if (stage === 'Dev') {
   const distributionWorkflowsBuildAccess: FineGrainedAccessSpecs = {
     users: ['opensearch-ci-bot'],
     roleName: 'distribution-workflow-build-role',
-    pattern: 'manifest-update',
-    templateName: 'builder-template',
-  };
-
-  const oscarBuildAccess: FineGrainedAccessSpecs = {
-    users: ['opensearch-ci-bot'],
-    roleName: 'oscar-build-role',
-    pattern: '(docker-scan|central-release-promotion)',
+    pattern: '(manifest-update|docker-scan)',
     templateName: 'builder-template',
   };
 
@@ -68,7 +61,7 @@ if (stage === 'Dev') {
     restrictServerAccessTo: stage === 'Prod' ? Peer.anyIpv4() : Peer.prefixList(prefixList.toString()),
     useProdAgents: true,
     enableViews: true,
-    fineGrainedAccessSpecs: [benchmarkFineGrainAccess, distributionWorkflowsBuildAccess, oscarBuildAccess],
+    fineGrainedAccessSpecs: [benchmarkFineGrainAccess, distributionWorkflowsBuildAccess],
     envVarsFilePath: './resources/envVars.yaml',
     env: {
       account: StageDefs[stage].accountId,

--- a/bin/ci-stack.ts
+++ b/bin/ci-stack.ts
@@ -50,6 +50,13 @@ if (stage === 'Dev') {
     templateName: 'builder-template',
   };
 
+  const oscarBuildAccess: FineGrainedAccessSpecs = {
+    users: ['opensearch-ci-bot'],
+    roleName: 'oscar-build-role',
+    pattern: '(docker-scan|central-release-promotion)',
+    templateName: 'builder-template',
+  };
+
   const ciStack = new CIStack(app, `OpenSearch-CI-${stage}`, {
     useSsl: true,
     authType: 'github',
@@ -61,7 +68,7 @@ if (stage === 'Dev') {
     restrictServerAccessTo: stage === 'Prod' ? Peer.anyIpv4() : Peer.prefixList(prefixList.toString()),
     useProdAgents: true,
     enableViews: true,
-    fineGrainedAccessSpecs: [benchmarkFineGrainAccess, distributionWorkflowsBuildAccess],
+    fineGrainedAccessSpecs: [benchmarkFineGrainAccess, distributionWorkflowsBuildAccess, oscarBuildAccess],
     envVarsFilePath: './resources/envVars.yaml',
     env: {
       account: StageDefs[stage].accountId,


### PR DESCRIPTION
### Description
Add OSCAR chatbot related build access role through opensearch-ci-bot

### Issues Resolved
https://github.com/opensearch-project/opensearch-build/issues/5684

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
