### PR TITLE
increase benchmark agents ebs size to 600G

### DIFF
--- a/lib/compute/agent-nodes.ts
+++ b/lib/compute/agent-nodes.ts
@@ -133,7 +133,7 @@ export class AgentNodes {
     };
     this.AL2023_X64_BENCHMARK_TEST = {
       agentType: 'unix',
-      customDeviceMapping: '/dev/xvda=:300:true:::encrypted',
+      customDeviceMapping: '/dev/xvda=:600:true:::encrypted',
       workerLabelString: ['Jenkins-Agent-AL2023-X64-M52xlarge-Benchmark-Test', 'benchmark'],
       instanceType: 'M52xlarge',
       remoteUser: 'ec2-user',
@@ -147,7 +147,7 @@ export class AgentNodes {
     };
     this.AL2023_X64_VECTOR_BENCHMARK_TEST = {
       agentType: 'unix',
-      customDeviceMapping: '/dev/xvda=:300:true:::encrypted',
+      customDeviceMapping: '/dev/xvda=:600:true:::encrypted',
       workerLabelString: ['Jenkins-Agent-AL2023-X64-M52xlarge-Vector-Benchmark-Test', 'benchmark'],
       instanceType: 'M52xlarge',
       remoteUser: 'ec2-user',


### PR DESCRIPTION
### Description
Increase benchmark agents ebs size to 600G as the newly introduced workload corpus can expand upto 250G. 

### Issues Resolved
_List any issues this PR will resolve, e.g. Closes [...]._ 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
