### PR TITLE
Enable OSD sql ml-commons benchmark to access bedrock in PRs

### DIFF
--- a/lib/secrets/iam-roles.ts
+++ b/lib/secrets/iam-roles.ts
@@ -18,7 +18,11 @@ export class AWSIdentityAccessManagementRolesStack {
 
     const reposWithBedrockAccessOnPrs = [
       'OpenSearch',
+      'OpenSearch-Dashboards',
       'opensearch-build',
+      'sql',
+      'ml-commons',
+      'opensearch-benchmark',
     ];
 
     reposWithBedrockAccessOnBranches.forEach((repo) => {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "opensearch-ci-stack",
-  "version": "1.5.3",
+  "version": "1.5.4",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "opensearch-ci-stack",
-      "version": "1.5.3",
+      "version": "1.5.4",
       "dependencies": {
         "@typescript-eslint/eslint-plugin": "^4.31.1",
         "@typescript-eslint/parser": "^4.31.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "opensearch-ci-stack",
-  "version": "1.5.3",
+  "version": "1.5.4",
   "bin": {
     "ci": "bin/ci-stack.js"
   },

--- a/test/ci-stack.test.ts
+++ b/test/ci-stack.test.ts
@@ -36,8 +36,8 @@ test('CI Stack Basic Resources', () => {
   template.resourceCountIs('AWS::AutoScaling::LaunchConfiguration', 1);
   template.resourceCountIs('AWS::ElasticLoadBalancingV2::LoadBalancer', 1);
   template.resourceCountIs('AWS::EC2::SecurityGroup', 4);
-  template.resourceCountIs('AWS::IAM::Policy', 39);
-  template.resourceCountIs('AWS::IAM::Role', 40);
+  template.resourceCountIs('AWS::IAM::Policy', 43);
+  template.resourceCountIs('AWS::IAM::Role', 44);
   template.resourceCountIs('AWS::S3::Bucket', 2);
   template.resourceCountIs('AWS::EC2::KeyPair', 1);
   template.resourceCountIs('AWS::IAM::InstanceProfile', 2);

--- a/test/secrets/iam-roles.test.ts
+++ b/test/secrets/iam-roles.test.ts
@@ -24,8 +24,8 @@ test('IAM Roles Stack Resources', () => {
 
   const template = Template.fromStack(stack);
 
-  template.resourceCountIs('AWS::IAM::Role', 3);
-  template.resourceCountIs('AWS::IAM::Policy', 3);
+  template.resourceCountIs('AWS::IAM::Role', 7);
+  template.resourceCountIs('AWS::IAM::Policy', 7);
 
   template.hasResourceProperties('AWS::IAM::Role', {
     RoleName: 'OpenSearch-bedrock-access-role-for-branches-public',


### PR DESCRIPTION
### Description
Enable OSD sql ml-commons benchmark to access bedrock in PRs

### Issues Resolved
https://github.com/opensearch-project/opensearch-build/issues/5912

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
