### PR TITLE
Switch to 3.9 get pip scripts on al2023

### DIFF
--- a/packer/scripts/al2023/al2023-agent-setups.sh
+++ b/packer/scripts/al2023/al2023-agent-setups.sh
@@ -29,7 +29,7 @@ if ! command -v "python3.9" > /dev/null; then
     exit 1
 fi
 
-curl -o- https://bootstrap.pypa.io/get-pip.py | python3
+curl -o- https://bootstrap.pypa.io/pip/3.9/get-pip.py | python3
 echo "export PATH=$PATH:$HOME/.local/bin" >> $HOME/.bashrc
 export PATH=$PATH:$HOME/.local/bin
 # https://github.com/opensearch-project/opensearch-build/issues/4946


### PR DESCRIPTION
### Description
Switch to 3.9 get pip scripts on al2023

### Issues Resolved
```
==> amazon-ebs.Jenkins-Agent-AL2023-X64-2026-05-05T06-01-57Z: + curl -o- https://bootstrap.pypa.io/get-pip.py
==> amazon-ebs.Jenkins-Agent-AL2023-X64-2026-05-05T06-01-57Z: + python3
==> amazon-ebs.Jenkins-Agent-AL2023-X64-2026-05-05T06-01-57Z:   % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
==> amazon-ebs.Jenkins-Agent-AL2023-X64-2026-05-05T06-01-57Z:                                  Dload  Upload   Total   Spent    Left  Speed
==> amazon-ebs.Jenkins-Agent-AL2023-X64-2026-05-05T06-01-57Z: 100  2174k 100  2174k   0     0 40346k     0  --:--:-- --:--:-- --:--:-- 41022k
    amazon-ebs.Jenkins-Agent-AL2023-X64-2026-05-05T06-01-57Z: ERROR: This script does not work on Python 3.9. The minimum supported Python version is 3.10. Please use https://bootstrap.pypa.io/pip/3.9/get-pip.py instead.
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
