### PR TITLE
Pin GitHub Actions to commit SHAs

### DIFF
--- a/.github/workflows/cdk.yml
+++ b/.github/workflows/cdk.yml
@@ -9,8 +9,8 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v6
-      - uses: actions/setup-node@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
           node-version: '20'
   

--- a/.github/workflows/config-helper.yml
+++ b/.github/workflows/config-helper.yml
@@ -14,8 +14,8 @@ jobs:
       run:
         working-directory: ./configHelper
     steps:
-      - uses: actions/checkout@v6
-      - uses: actions/setup-python@v5
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with:
           python-version: ${{ env.python-version }}
       - run: |

--- a/.github/workflows/deploy-stacks.yml
+++ b/.github/workflows/deploy-stacks.yml
@@ -12,10 +12,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Setup Node and install cdk cli
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
           node-version: 20.x
 
@@ -33,7 +33,7 @@ jobs:
           echo "REGION=us-east-1" >> $GITHUB_ENV
 
       - id: get_approvers
-        uses: actions/github-script@v7
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           result-encoding: json
@@ -50,7 +50,7 @@ jobs:
             const maintainers = collaborators.filter(c => c.permissions.maintain).map(c => c.login);
             return maintainers;
       - name: Configure beta deployment credentials
-        uses: aws-actions/configure-aws-credentials@v6
+        uses: aws-actions/configure-aws-credentials@d979d5b3a71173a29b74b5b88418bfda9437d885 # v6
         with:
           role-to-assume: ${{ secrets.BETA_DEPLOYMENT_ROLE }}
           aws-region: 'us-east-1'
@@ -68,13 +68,13 @@ jobs:
             echo "EOF" >> $GITHUB_OUTPUT
           fi
       - name: Upload beta diff as artifact
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6
         with:
           name: beta-stack-diff
           path: beta_diff.txt
           retention-days: 30
       - name: Approve or Deny beta change set
-        uses: trstringer/manual-approval@v1
+        uses: trstringer/manual-approval@74d99dff7380e3e4b122d4ededcbca2b6ce59367 # v1
         with:
           secret: ${{ secrets.GITHUB_TOKEN }}
           approvers: ${{ join(fromJSON(steps.get_approvers.outputs.result), ', ') }}
@@ -99,7 +99,7 @@ jobs:
         run: |
           cdk deploy "*" -c stage=Beta --require-approval=never
       - name: Configure Production deployment credentials
-        uses: aws-actions/configure-aws-credentials@v6
+        uses: aws-actions/configure-aws-credentials@d979d5b3a71173a29b74b5b88418bfda9437d885 # v6
         with:
           role-to-assume: ${{ secrets.PROD_DEPLOYMENT_ROLE }}
           aws-region: 'us-east-1'
@@ -119,13 +119,13 @@ jobs:
             echo "EOF" >> $GITHUB_OUTPUT
           fi
       - name: Upload production diff as artifact
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6
         with:
           name: production-stack-diff
           path: prod_diff.txt
           retention-days: 30
       - name: Approve or Deny Production change set
-        uses: trstringer/manual-approval@v1
+        uses: trstringer/manual-approval@74d99dff7380e3e4b122d4ededcbca2b6ce59367 # v1
         with:
           secret: ${{ secrets.GITHUB_TOKEN }}
           approvers: ${{ join(fromJSON(steps.get_approvers.outputs.result), ', ') }}

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -10,19 +10,19 @@ jobs:
     steps:
       -
         name: Set up QEMU
-        uses: docker/setup-qemu-action@v2
+        uses: docker/setup-qemu-action@2b82ce82d56a2a04d2637cd93a637ae1b359c0a7 # v2
       -
         name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v1
+        uses: docker/setup-buildx-action@f211e3e9ded2d9377c8cadc4489a4e38014bc4c9 # v1
       -
         name: Login to DockerHub
-        uses: docker/login-action@v1
+        uses: docker/login-action@dd4fa0671be5250ee6f50aedf4cb05514abda2c7 # v1
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
       -
         name: Build and push
-        uses: docker/build-push-action@v2
+        uses: docker/build-push-action@ac9327eae2b366085ac7f6a2d02df8aa8ead720a # v2
         with:
           platforms: linux/amd64,linux/arm64
           context: "{{defaultContext}}:docker"

--- a/.github/workflows/packer.yml
+++ b/.github/workflows/packer.yml
@@ -14,10 +14,10 @@ jobs:
     name: Run Packer
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Setup packer
-        uses: hashicorp/setup-packer@v3
+        uses: hashicorp/setup-packer@1aa358be5cf73883762b302a3a03abd66e75b232 # v3
         id: setup
         with:
           version: ${{ env.PACKER_VERSION }}

--- a/.github/workflows/plantuml.yml
+++ b/.github/workflows/plantuml.yml
@@ -13,7 +13,7 @@ jobs:
         UML_FILES: ".puml"
     steps:
       - name: Checkout Source 
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           fetch-depth: 0
       - name: Get changed UML files
@@ -42,7 +42,7 @@ jobs:
             args: -v -tpng ${{ steps.getfile.outputs.files }}
       - name: Push Local Changes
         if: success()
-        uses:  stefanzweifel/git-auto-commit-action@v4.1.2 
+        uses:  stefanzweifel/git-auto-commit-action@dd055f6225757c369f948744463f63ac1bd4c277 # v4.1.2 
         with: 
           commit_message: "Generate SVG and PNG images for PlantUML diagrams" 
           branch: ${{ github.head_ref }}


### PR DESCRIPTION
### Description

Pin all GitHub Action tag references to their corresponding commit SHAs.

Tags are mutable references that can be force-pushed to point to different commits, making them vulnerable to supply chain attacks. Commit SHAs are immutable and guarantee that the exact reviewed code is executed in CI workflows. This change pins all third-party actions to their current commit SHAs to prevent potential tampering.