### PR TITLE
add new single executor for benchmark runs

### DIFF
--- a/lib/compute/agent-nodes.ts
+++ b/lib/compute/agent-nodes.ts
@@ -26,6 +26,8 @@ export class AgentNodes {
 
   readonly AL2023_X64_BENCHMARK_TEST: AgentNodeProps;
 
+  readonly AL2023_X64_BENCHMARK_TEST_SINGLE_EXECUTOR: AgentNodeProps;
+
   readonly AL2023_X64_VECTOR_BENCHMARK_TEST: AgentNodeProps;
 
   readonly UBUNTU2404_X64_GRADLE_CHECK: AgentNodeProps;
@@ -140,6 +142,20 @@ export class AgentNodes {
       maxTotalUses: 10,
       minimumNumberOfSpareInstances: 1,
       numExecutors: 2,
+      amiId: 'ami-0534165cc639704af',
+      initScript: 'sudo dnf clean all && sudo rm -rf /var/cache/dnf && sudo dnf repolist &&'
+        + ' sudo dnf update --releasever=latest --skip-broken --exclude=openssh* --exclude=docker* --exclude=gh* --exclude=openssl* -y && docker ps',
+      remoteFs: '/var/jenkins',
+    };
+    this.AL2023_X64_BENCHMARK_TEST_SINGLE_EXECUTOR = {
+      agentType: 'unix',
+      customDeviceMapping: '/dev/xvda=:2500:true:gp3:6000:encrypted:500',
+      workerLabelString: ['Jenkins-Agent-AL2023-X64-M52xlarge-Benchmark-Test-Single-Exec', 'benchmark'],
+      instanceType: 'M52xlarge',
+      remoteUser: 'ec2-user',
+      maxTotalUses: 10,
+      minimumNumberOfSpareInstances: 1,
+      numExecutors: 1,
       amiId: 'ami-0534165cc639704af',
       initScript: 'sudo dnf clean all && sudo rm -rf /var/cache/dnf && sudo dnf repolist &&'
         + ' sudo dnf update --releasever=latest --skip-broken --exclude=openssh* --exclude=docker* --exclude=gh* --exclude=openssl* -y && docker ps',

--- a/test/ci-stack.test.ts
+++ b/test/ci-stack.test.ts
@@ -415,12 +415,12 @@ describe('AgentNodes', () => {
 
   it('should exclude "default" keys when type is "BTR"', () => {
     const result = agentNodes.getRequiredAgentNodes('BTR');
-    expect(result.length).toBe(15);
+    expect(result.length).toBe(16);
   });
 
   it('should return keys containing "benchmark" when type is "benchmark"', () => {
     const result = agentNodes.getRequiredAgentNodes('benchmark');
-    expect(result).toHaveLength(2);
+    expect(result).toHaveLength(3);
   });
 
   it('should return keys containing "gradle" when type is "gradle"', () => {


### PR DESCRIPTION
### Description
Adding new benchmark agent with max parallel executors set to 1 and run indexing only benchmarks. 
Currently running two parallel ingestion tests on the same agent by mounting the same data directory drastically reduces ingestion throughput due to multiple osb process contesting to read from same file. 

### Issues Resolved
_List any issues this PR will resolve, e.g. Closes [...]._ 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
