### PR TITLE
Switch macos arm64 packer tempates to replace mac2.m2-pro.metal with mac2.m2.metal

### DIFF
--- a/packer/jenkins-agent-macos14-arm64.json
+++ b/packer/jenkins-agent-macos14-arm64.json
@@ -19,7 +19,7 @@
       "encrypt_boot": "false",
       "region": "{{user `build-region`}}",
       "ami_regions": "{{user `aws_ami_region`}}",
-      "instance_type": "mac2-m2pro.metal",
+      "instance_type": "mac2-m2.metal",
       "ami_name": "{{user `ami_name`}}-{{user `os_version`}}-{{user `build-time`}}",
       "vpc_id": "{{user `build-vpc`}}",
       "subnet_id": "{{user `build-subnet`}}",


### PR DESCRIPTION


### Description
Switch macos arm64 packer tempates to replace mac2.m2-pro.metal with mac2.m2.metal.

We are unlikely to update the build.ci.opensearch.org macos agent anymore, support LF jenkins.

### Issues Resolved
https://github.com/opensearch-project/opensearch-build/issues/6244

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
