### PR TITLE
Prevent brew cleanup from failing the entire builds

### DIFF
--- a/packer/scripts/macos/macos-agentsetup.sh
+++ b/packer/scripts/macos/macos-agentsetup.sh
@@ -60,7 +60,7 @@ $BREW_PATH/brew install ca-certificates
 $BREW_PATH/brew install gnupg
 $BREW_PATH/brew install 1password-cli
 $BREW_PATH/brew install protobuf
-$BREW_PATH/brew cleanup
+$BREW_PATH/brew cleanup || echo brew has issues when cleanup cache
 
 
 ## Loop through JDK versions and install them


### PR DESCRIPTION
### Description
Prevent brew cleanup from failing the entire builds

### Issues Resolved
https://github.com/opensearch-project/opensearch-build/issues/6244

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
